### PR TITLE
Create valid OSGI Headers for byte buddy.

### DIFF
--- a/byte-buddy-agent/pom.xml
+++ b/byte-buddy-agent/pom.xml
@@ -9,11 +9,10 @@
     </parent>
 
     <artifactId>byte-buddy-agent</artifactId>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
 
     <properties>
         <bytebuddy.agent>net.bytebuddy.agent.ByteBuddyAgent$Installer</bytebuddy.agent>
-        <version.plugin.jar>2.4</version.plugin.jar>
     </properties>
 
     <name>Byte Buddy Java agent</name>
@@ -34,27 +33,29 @@
 
     <build>
         <plugins>
-            <!-- Configure both agent use and OSGI -->
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>${version.plugin.jar}</version>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>${version.plugin.bundle}</version>
+                <extensions>true</extensions>
                 <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <Premain-Class>${bytebuddy.agent}</Premain-Class>
-                            <Agent-Class>${bytebuddy.agent}</Agent-Class>
-                            <Can-Redefine-Classes>true</Can-Redefine-Classes>
-                            <Can-Retransform-Classes>true</Can-Retransform-Classes>
-                            <Can-Set-Native-Method-Prefix>true</Can-Set-Native-Method-Prefix>
-                            <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
-                            <Bundle-Name>${project.name}</Bundle-Name>
-                            <Bundle-Description>${project.description}</Bundle-Description>
-                            <Bundle-Version>${project.version}</Bundle-Version>
-                            <Export-Package>net.bytebuddy.*</Export-Package>
-                        </manifestEntries>
-                    </archive>
+                    <instructions>
+                        <Premain-Class>${bytebuddy.agent}</Premain-Class>
+                        <Agent-Class>${bytebuddy.agent}</Agent-Class>
+                        <Can-Redefine-Classes>true</Can-Redefine-Classes>
+                        <Can-Retransform-Classes>true</Can-Retransform-Classes>
+                        <Can-Set-Native-Method-Prefix>true</Can-Set-Native-Method-Prefix>
+                        <Import-Package>com.sun.tools.attach;resolution:="optional"</Import-Package>
+                    </instructions>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle</id>
+                        <goals>
+                            <goal>bundle</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/byte-buddy-dep/pom.xml
+++ b/byte-buddy-dep/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>byte-buddy-dep</artifactId>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
 
     <name>Byte Buddy (with dependencies)</name>
     <description>
@@ -55,5 +55,22 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>${version.plugin.bundle}</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <id>bundle</id>
+                        <goals>
+                            <goal>bundle</goal>
+                        </goals>
+                    </execution>
+                </executions>
+              </plugin>
+          </plugins>
+      </build>
 </project>

--- a/byte-buddy/pom.xml
+++ b/byte-buddy/pom.xml
@@ -67,6 +67,30 @@
             </activation>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.apache.felix</groupId>
+                        <artifactId>maven-bundle-plugin</artifactId>
+                        <version>${version.plugin.bundle}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <instructions>
+                                <Export-Package>!${shade.source}.*,net.bytebuddy.*</Export-Package>
+                                <Import-Package>!${shade.source}.*</Import-Package>
+                                <Private-Package>${shade.source}.*</Private-Package>
+                                <Embed-Dependency>byte-buddy-dep;inline=true</Embed-Dependency>
+                                <Embed-Transitive>true</Embed-Transitive>
+                            </instructions>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>bundle</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>bundle</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <!-- Shade the ASM dependency and define OSGI manifest -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -89,18 +113,15 @@
                                             <shadedPattern>${shade.target}</shadedPattern>
                                         </relocation>
                                     </relocations>
-                                    <transformers>
-                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                            <manifestEntries>
-                                                <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
-                                                <Bundle-Name>${project.name}</Bundle-Name>
-                                                <Bundle-Description>${project.description}</Bundle-Description>
-                                                <Bundle-Version>${project.version}</Bundle-Version>
-                                                <Export-Package>!${shade.target}.*,net.bytebuddy.*</Export-Package>
-                                                <Private-Package>${shade.target}.*</Private-Package>
-                                            </manifestEntries>
-                                        </transformer>
-                                    </transformers>
+                                    <artifactSet>
+                                        <includes>
+                                            <!--
+                                            trick to avoid warnings from shade plugin because package
+                                            is already embedded by private-package instruction from bundle plugin
+                                            -->
+                                            <include>null:null</include>
+                                        </includes>
+                                    </artifactSet>
                                 </configuration>
                             </execution>
                         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <version.asm>5.0.3</version.asm>
         <version.junit>4.12</version.junit>
         <version.mockito>1.10.19</version.mockito>
+        <version.plugin.bundle>2.5.4</version.plugin.bundle>
         <version.plugin.compiler>3.1</version.plugin.compiler>
         <version.plugin.install>2.5.1</version.plugin.install>
         <version.plugin.deploy>2.8.2</version.plugin.deploy>


### PR DESCRIPTION
This change introduces the maven-bundle-plugin to generate the correct
MANIFEST.MF values. Due to the internal structure of byte buddy, these
are pretty long. The build procedure also generates a few warnings about
nonstandard osgi behaviour, which is ok, but might encourage future
refactorings.