### PR TITLE
Instruct checkstyle not to use the system default line separator

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -4,7 +4,9 @@
         "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 <module name="Checker">
     <module name="JavadocPackage"/>
-    <module name="NewlineAtEndOfFile"/>
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf" />
+    </module>
     <module name="FileTabCharacter"/>
 
     <module name="RegexpSingleline">


### PR DESCRIPTION
On Windows the build fails because the NewlineAtEndOfFile check takes the
system default line separator into account.