### PR TITLE
FixedValue.value(String.class) returns Class<Class> instead of Class<String>

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/FixedValue.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/FixedValue.java
@@ -97,7 +97,7 @@ public abstract class FixedValue implements Implementation {
                     Assigner.DEFAULT,
                     Assigner.STATICALLY_TYPED);
         } else if (type == Class.class) {
-            return new ForPoolValue(ClassConstant.of(new TypeDescription.ForLoadedType(type)),
+            return new ForPoolValue(ClassConstant.of(new TypeDescription.ForLoadedType((Class<?>) fixedValue)),
                     TypeDescription.CLASS,
                     Assigner.DEFAULT,
                     Assigner.STATICALLY_TYPED);

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/FixedValueTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/FixedValueTest.java
@@ -49,6 +49,13 @@ public class FixedValueTest extends AbstractImplementationTest {
     }
 
     @Test
+    public void testClassConstantPool() throws Exception {
+        Class<? extends Qux> qux = implement(Qux.class, FixedValue.value(Object.class)).getLoaded();
+        assertThat(qux.getDeclaredFields().length, is(0));
+        assertEquals(Object.class, qux.newInstance().bar());
+    }
+
+    @Test
     @JavaVersionRule.Enforce(7)
     public void testMethodTypeConstantPool() throws Exception {
         Class<? extends Qux> qux = implement(Qux.class, FixedValue.value(JavaInstance.MethodType.of(void.class, Object.class))).getLoaded();


### PR DESCRIPTION
When passing a class to FixedValue.value() load the passed class instead of the class of the passed class.