### PR TITLE
Do not retransform an empty array.

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/agent/builder/AgentBuilder.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/agent/builder/AgentBuilder.java
@@ -1014,10 +1014,12 @@ public interface AgentBuilder {
                         }
                     }
                 }
-                try {
-                    instrumentation.retransformClasses(retransformedTypes.toArray(new Class<?>[retransformedTypes.size()]));
-                } catch (UnmodifiableClassException exception) {
-                    throw new IllegalStateException("Cannot retransform classes: " + retransformedTypes, exception);
+                if (retransformedTypes.size() > 0) {
+                  try {
+                      instrumentation.retransformClasses(retransformedTypes.toArray(new Class<?>[retransformedTypes.size()]));
+                  } catch (UnmodifiableClassException exception) {
+                      throw new IllegalStateException("Cannot retransform classes: " + retransformedTypes, exception);
+                  }
                 }
             }
             return classFileTransformer;

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/agent/builder/AgentBuilderDefaultTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/agent/builder/AgentBuilderDefaultTest.java
@@ -131,7 +131,7 @@ public class AgentBuilderDefaultTest {
     }
 
     @Test
-    public void testSuccessfulWithRetransformationNonMatched() throws Exception {
+    public void testSkipRetransformationWithNonMatched() throws Exception {
         when(unloaded.getBytes()).thenReturn(BAZ);
         when(resolution.resolve()).thenReturn(typeDescription);
         when(rawMatcher.matches(typeDescription, classLoader, REDEFINED, protectionDomain)).thenReturn(true);
@@ -148,8 +148,8 @@ public class AgentBuilderDefaultTest {
         verify(listener).onComplete(FOO);
         verifyNoMoreInteractions(listener);
         verify(instrumentation).addTransformer(classFileTransformer, true);
-        verify(instrumentation).retransformClasses();
         verify(instrumentation).getAllLoadedClasses();
+        verify(instrumentation, never()).retransformClasses();
         verifyNoMoreInteractions(instrumentation);
     }
 
@@ -166,8 +166,8 @@ public class AgentBuilderDefaultTest {
         assertThat(classFileTransformers.size(), is(1));
         verifyZeroInteractions(listener);
         verify(instrumentation).addTransformer(classFileTransformer, true);
-        verify(instrumentation).retransformClasses(REDEFINED);
         verify(instrumentation).getAllLoadedClasses();
+        verify(instrumentation).retransformClasses(REDEFINED);
         verifyNoMoreInteractions(instrumentation);
     }
 


### PR DESCRIPTION
Transforming an empty array/list would throw:
*** java.lang.instrument ASSERTION FAILED ***: "numClasses != 0" at JPLISAgent.c line: 1102