### PR TITLE
Fix net.bytebuddy.implementation.attribute.AnnotationAppender.ValueFilter.SkipDefaults#sRelevant(...)

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/attribute/AnnotationAppender.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/attribute/AnnotationAppender.java
@@ -343,7 +343,7 @@ public interface AnnotationAppender {
             @Override
             public boolean isRelevant(AnnotationDescription annotationDescription, MethodDescription.InDefinedShape methodDescription) {
                 Object defaultValue = methodDescription.getDefaultValue();
-                return defaultValue != null && defaultValue.equals(annotationDescription.getValue(methodDescription));
+                return defaultValue == null || !defaultValue.equals(annotationDescription.getValue(methodDescription));
             }
 
             @Override

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/attribute/AnnotationAppenderValueFilterSkipDefaultsTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/attribute/AnnotationAppenderValueFilterSkipDefaultsTest.java
@@ -26,7 +26,7 @@ public class AnnotationAppenderValueFilterSkipDefaultsTest {
 
     @Test
     public void testFilteringNoDefault() throws Exception {
-        assertThat(AnnotationAppender.ValueFilter.SkipDefaults.INSTANCE.isRelevant(annotationDescription, methodDescription), is(false));
+        assertThat(AnnotationAppender.ValueFilter.SkipDefaults.INSTANCE.isRelevant(annotationDescription, methodDescription), is(true));
         verifyZeroInteractions(annotationDescription);
         verify(methodDescription).getDefaultValue();
         verifyNoMoreInteractions(methodDescription);
@@ -36,7 +36,7 @@ public class AnnotationAppenderValueFilterSkipDefaultsTest {
     public void testFilteringNoEquality() throws Exception {
         when(methodDescription.getDefaultValue()).thenReturn(new Object());
         when(annotationDescription.getValue(methodDescription)).thenReturn(new Object());
-        assertThat(AnnotationAppender.ValueFilter.SkipDefaults.INSTANCE.isRelevant(annotationDescription, methodDescription), is(false));
+        assertThat(AnnotationAppender.ValueFilter.SkipDefaults.INSTANCE.isRelevant(annotationDescription, methodDescription), is(true));
         verify(annotationDescription).getValue(methodDescription);
         verifyNoMoreInteractions(annotationDescription);
         verify(methodDescription).getDefaultValue();
@@ -48,7 +48,7 @@ public class AnnotationAppenderValueFilterSkipDefaultsTest {
         Object value = new Object();
         when(methodDescription.getDefaultValue()).thenReturn(value);
         when(annotationDescription.getValue(methodDescription)).thenReturn(value);
-        assertThat(AnnotationAppender.ValueFilter.SkipDefaults.INSTANCE.isRelevant(annotationDescription, methodDescription), is(true));
+        assertThat(AnnotationAppender.ValueFilter.SkipDefaults.INSTANCE.isRelevant(annotationDescription, methodDescription), is(false));
         verify(annotationDescription).getValue(methodDescription);
         verifyNoMoreInteractions(annotationDescription);
         verify(methodDescription).getDefaultValue();


### PR DESCRIPTION
`SkipDefaults#isRelevant(...)` should include non-default values, thus it should return `true` iff the value is not a default.

The existing logic was backwards.