### PR TITLE
Don't use TypeDescription#getInternalName but #getName in equals to improve performance a bit

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/description/type/TypeDescription.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/description/type/TypeDescription.java
@@ -7194,7 +7194,7 @@ public interface TypeDescription extends TypeDefinition, TypeVariableSource {
         public boolean equals(Object other) {
             return other == this || other instanceof TypeDefinition
                     && ((TypeDefinition) other).getSort().isNonGeneric()
-                    && getInternalName().equals(((TypeDefinition) other).asErasure().getInternalName());
+                    && getName().equals(((TypeDefinition) other).asErasure().getName());
         }
 
         @Override

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/description/type/AbstractTypeDescriptionTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/description/type/AbstractTypeDescriptionTest.java
@@ -222,7 +222,7 @@ public abstract class AbstractTypeDescriptionTest extends AbstractTypeDescriptio
         TypeDescription equalFirst = mock(TypeDescription.class);
         when(equalFirst.getSort()).thenReturn(TypeDefinition.Sort.NON_GENERIC);
         when(equalFirst.asErasure()).thenReturn(equalFirst);
-        when(equalFirst.getInternalName()).thenReturn(Type.getInternalName(SampleClass.class));
+        when(equalFirst.getName()).thenReturn(SampleClass.class.getName());
         assertThat(describe(SampleClass.class), is(equalFirst));
         assertThat(describe(SampleClass.class), not(describe(SampleInterface.class)));
         assertThat(describe(SampleClass.class), not((TypeDescription) new TypeDescription.ForLoadedType(SampleInterface.class)));

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/dynamic/scaffold/InstrumentedTypeDefaultTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/dynamic/scaffold/InstrumentedTypeDefaultTest.java
@@ -355,11 +355,11 @@ public class InstrumentedTypeDefaultTest {
     public void testEquals() throws Exception {
         InstrumentedType instrumentedType = makePlainInstrumentedType();
         TypeDescription other = mock(TypeDescription.class);
-        when(other.getInternalName()).thenReturn(instrumentedType.getInternalName());
+        when(other.getName()).thenReturn(instrumentedType.getName());
         when(other.getSort()).thenReturn(TypeDefinition.Sort.NON_GENERIC);
         when(other.asErasure()).thenReturn(other);
         assertThat(instrumentedType, is(other));
-        verify(other, atLeast(1)).getInternalName();
+        verify(other, atLeast(1)).getName();
     }
 
     @Test


### PR DESCRIPTION
All getInternalName does is calling `getName().replace('.', '/')` anyway

This was revealed by using Flight recorder.

<img width="975" alt="getinternalname" src="https://cloud.githubusercontent.com/assets/2163464/14936942/26c3b750-0ef9-11e6-8b63-05769707fbdc.png">
