### PR TITLE
Added additional checking for common errors during compile time using google errorprone

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,8 @@
         <version.plugin.jitwatch>1.0.1</version.plugin.jitwatch>
         <version.plugin.clirr>2.7</version.plugin.clirr>
         <version.android.sdk>4.1.1.4</version.android.sdk>
+        <version.plugin.javac-errorprone>2.8</version.plugin.javac-errorprone>
+        <version.plugin.errorprone>2.0.9</version.plugin.errorprone>
     </properties>
 
     <licenses>
@@ -285,7 +287,24 @@
                         <source>${code.level}</source>
                         <target>${code.level}</target>
                         <encoding>${project.build.sourceEncoding}</encoding>
+                        <compilerId>javac-with-errorprone</compilerId>
+                        <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                        <showWarnings>true</showWarnings>
+                        <showDeprecation>true</showDeprecation>
+                        <compilerArgument>-XepDisableWarningsInGeneratedCode</compilerArgument>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.codehaus.plexus</groupId>
+                            <artifactId>plexus-compiler-javac-errorprone</artifactId>
+                            <version>${version.plugin.javac-errorprone}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>com.google.errorprone</groupId>
+                            <artifactId>error_prone_core</artifactId>
+                            <version>${version.plugin.errorprone}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Google Errorprone (http://errorprone.info/) is a small enhancement of the javac compiler to catch more programming mistakes. While some could be considered also "style" (like lowercase L for marking longs) it can never harm to have an additional level of checking.