### PR TITLE
Fail gradle build when incremental compilation is enabled

### DIFF
--- a/byte-buddy-gradle-plugin/src/main/java/net/bytebuddy/build/gradle/TransformationAction.java
+++ b/byte-buddy-gradle-plugin/src/main/java/net/bytebuddy/build/gradle/TransformationAction.java
@@ -14,6 +14,8 @@ import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.tasks.compile.AbstractCompile;
+import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.api.tasks.scala.ScalaCompile;
 
 import java.io.File;
 import java.io.IOException;
@@ -62,9 +64,25 @@ public class TransformationAction implements Action<Task> {
     @Override
     public void execute(Task task) {
         try {
+            verifyCompilationNotIncremental(task);
             processOutputDirectory(this.task.getDestinationDir(), this.task.getClasspath());
         } catch (IOException exception) {
             throw new GradleException("Error accessing file system", exception);
+        }
+    }
+
+    private void verifyCompilationNotIncremental(Task task) {
+        if (task instanceof JavaCompile) {
+            JavaCompile javaCompileTask = (JavaCompile) task;
+            if (javaCompileTask.getOptions().isIncremental()) {
+                throw new GradleException("Transformations aren't supported when incremental compilation is enabled. Set " + javaCompileTask.getName() + ".options.incremental=false in the build file.");
+            }
+        }
+        if (task instanceof ScalaCompile) {
+            ScalaCompile scalaCompileTask = (ScalaCompile) task;
+            if (!scalaCompileTask.getScalaCompileOptions().isForce()) {
+                throw new GradleException("Transformations aren't supported when incremental compilation is enabled. Set " + scalaCompileTask.getName() + ".scalaCompileOptions.force=true in the build file.");
+            }
         }
     }
 

--- a/byte-buddy-gradle-plugin/src/test/java/net/bytebuddy/build/gradle/ByteBuddyPluginTest.java
+++ b/byte-buddy-gradle-plugin/src/test/java/net/bytebuddy/build/gradle/ByteBuddyPluginTest.java
@@ -73,6 +73,29 @@ public class ByteBuddyPluginTest {
 
     @Test
     public void testGradlePlugin() throws IOException {
+        createSampleBuildFiles();
+        BuildResult result = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(temporaryFolder.getRoot()).withArguments("-s", "run")
+                .forwardOutput()
+                .build();
+        assertThat(result.task(":classes").getOutcome(), is(TaskOutcome.SUCCESS));
+        assertThat(result.getOutput(), CoreMatchers.containsString("foo=qux"));
+    }
+
+    @Test
+    public void testIncrementalCompilationFails() throws IOException {
+        createSampleBuildFiles();
+        append("compileJava.options.incremental = true", new File(temporaryFolder.getRoot(), "build.gradle"));
+        BuildResult result = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(temporaryFolder.getRoot()).withArguments("classes")
+                .forwardOutput()
+                .buildAndFail();
+        assertThat(result.getOutput(), CoreMatchers.containsString("Transformations aren't supported when incremental compilation is enabled."));
+    }
+
+    private void createSampleBuildFiles() throws IOException {
         store("plugins {\n" +
                 "    id 'java'\n" +
                 "    id 'application'\n" +
@@ -90,7 +113,7 @@ public class ByteBuddyPluginTest {
                 "        classPath = configurations.sample\n" +
                 "    }\n" +
                 "}\n" +
-                "mainClassName = 'net.bytebuddy.test.Sample'", temporaryFolder.newFile("build.gradle"));
+                "mainClassName = 'net.bytebuddy.test.Sample'\n", temporaryFolder.newFile("build.gradle"));
         store("package net.bytebuddy.test;\n" +
                 "public class Sample {\n" +
                 "    public String foo() {\n" +
@@ -100,19 +123,20 @@ public class ByteBuddyPluginTest {
                 "        System.out.println(\"foo=\" + new Sample().foo());\n" +
                 "    }\n" +
                 "}\n", new File(temporaryFolder.newFolder("src", "main", "java", "net", "bytebuddy", "test"), "Sample.java"));
-        BuildResult result = GradleRunner.create()
-                .withPluginClasspath()
-                .withProjectDir(temporaryFolder.getRoot()).withArguments("-s", "run")
-                .forwardOutput()
-                .build();
-        assertThat(result.task(":classes").getOutcome(), is(TaskOutcome.SUCCESS));
-        assertThat(result.getOutput(), CoreMatchers.containsString("foo=qux"));
     }
 
     private static void store(String source, File target) throws IOException {
+        store(source, target, false);
+    }
+
+    private static void append(String source, File target) throws IOException {
+        store(source, target, true);
+    }
+
+    private static void store(String source, File target, boolean append) throws IOException {
         InputStream inputStream = new ByteArrayInputStream(source.getBytes("UTF-8"));
         try {
-            OutputStream outputStream = new FileOutputStream(target);
+            OutputStream outputStream = new FileOutputStream(target, append);
             try {
                 byte[] buffer = new byte[1024];
                 int length;


### PR DESCRIPTION
My assumption is that the transformation action doesn't keep track of the files that have already been processed. Therefore the build should fail when incremental compilation is enabled.