### PR TITLE
Fix gradle plugin

### DIFF
--- a/byte-buddy-gradle-plugin/pom.xml
+++ b/byte-buddy-gradle-plugin/pom.xml
@@ -105,6 +105,7 @@
                 <version>${version.plugin.antrun}</version>
                 <executions>
                     <execution>
+                        <id>copy-jar</id>
                         <phase>package</phase>
                         <goals>
                             <goal>run</goal>
@@ -132,6 +133,7 @@
                         <version>${version.plugin.antrun}</version>
                         <executions>
                             <execution>
+                                <id>copy-javadoc</id>
                                 <phase>package</phase>
                                 <goals>
                                     <goal>run</goal>


### PR DESCRIPTION
The gradle plugin as currently published to maven central is not functional, as it doesn't include the plugin classes compiled by gradle. The maven-antrun-plugin execution defined in 'extras' profile (that copies the javadoc) is conflicting with the execution that copies the jar, with the result that only the javadoc is copied. The solution is to add a unique execution id to each execution, so that both executions are run.