### PR TITLE
Revert TerminationHandler.resolve() back to public.

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/bind/annotation/TargetMethodAnnotationDrivenBinder.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/bind/annotation/TargetMethodAnnotationDrivenBinder.java
@@ -546,7 +546,7 @@ public class TargetMethodAnnotationDrivenBinder implements MethodDelegationBinde
          */
         RETURNING {
             @Override
-            protected StackManipulation resolve(Assigner assigner, MethodDescription source, MethodDescription target) {
+            public StackManipulation resolve(Assigner assigner, MethodDescription source, MethodDescription target) {
                 return new StackManipulation.Compound(assigner.assign(target.isConstructor()
                                 ? target.getDeclaringType().asGenericType()
                                 : target.getReturnType(),
@@ -560,7 +560,7 @@ public class TargetMethodAnnotationDrivenBinder implements MethodDelegationBinde
          */
         DROPPING {
             @Override
-            protected StackManipulation resolve(Assigner assigner, MethodDescription source, MethodDescription target) {
+            public StackManipulation resolve(Assigner assigner, MethodDescription source, MethodDescription target) {
                 return Removal.pop(target.isConstructor()
                         ? target.getDeclaringType().asErasure()
                         : target.getReturnType().asErasure());
@@ -575,7 +575,7 @@ public class TargetMethodAnnotationDrivenBinder implements MethodDelegationBinde
          * @param target   The target method that is subject to be bound by the {@code source} method.
          * @return A stack manipulation that is applied after the method return.
          */
-        protected abstract StackManipulation resolve(Assigner assigner, MethodDescription source, MethodDescription target);
+        public abstract StackManipulation resolve(Assigner assigner, MethodDescription source, MethodDescription target);
 
         @Override
         public String toString() {


### PR DESCRIPTION
We hit this backward incompatible change when we upgrade. It blocks us from upgrading to mockito 2.

Was reducing visibility intentional, and what is the alternative?

It is used in:
https://github.com/apache/incubator-beam/blob/master/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java#L469

It surprised me that backward incompatible changes are made within one major version. Followings two are also backward incompatible but easier to fix:
MethodVariableAccess.loadOffset() -> loadFrom()
MethodReturn.returning() -> of()