### PR TITLE
Add configuration for jacoco-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
         <version.plugin.animal-sniffer>1.14</version.plugin.animal-sniffer>
         <version.plugin.enforcer>1.4.1</version.plugin.enforcer>
         <version.plugin.cobertura>2.7</version.plugin.cobertura>
+        <version.plugin.jacoco>0.7.7.201606060606</version.plugin.jacoco>
         <version.plugin.coveralls>4.1.0</version.plugin.coveralls>
         <version.plugin.checkstyle>2.17</version.plugin.checkstyle>
         <version.plugin.findbugs>3.0.3</version.plugin.findbugs>
@@ -217,6 +218,26 @@
                         <format>xml</format>
                     </formats>
                     <check />
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${version.plugin.jacoco}</version>
+                <configuration>
+                    <includes>
+                        <include>net/bytebuddy/**</include>
+                    </includes>
+                    <excludes>
+                        <exclude>net/bytebuddy/benchmark/generated/*</exclude>
+                        <!--
+                          JaCoCo adds additional synthetic members to classes,
+                          ByteBuddy tests inspect members,
+                          so exclude test classes from instrumentation to avoid failures of assertions
+                        -->
+                        <exclude>*Test*</exclude>
+                        <exclude>*test*</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
             <!-- Generate coveralls reports from Travis. -->


### PR DESCRIPTION
For reasons described below, I propose to use JaCoCo instead of Cobertura.

Seems that Cobertura causes failure that is described in #229.

Also seems that Cobertura has difficulties to parse some ByteBuddy source files, for example:
```
$ mvn -V clean cobertura:cobertura -Pjava7 -Pintegration
...
Java version: 1.7.0_80, vendor: Oracle Corporation
...
[INFO] --- cobertura-maven-plugin:2.7:cobertura (default-cli) @ byte-buddy-dep ---
[INFO] Cobertura 2.1.1 - GNU GPL License (NO WARRANTY) - See COPYRIGHT file
[INFO] Cobertura: Loaded information on 1741 classes.
[WARN] JavaNCSS got an error while parsing the java file /home/godin/projects/jacoco/byte-buddy/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/auxiliary/AuxiliaryT
ype.java
ParseException in STDIN
Last useful checkpoint: "net.bytebuddy.implementation.auxiliary.AuxiliaryType"
Encountered " "interface" "interface "" at line 184, column 6.
```

As well as difficulties with Java 8 - many test failures:
```
$ mvn -V cobertura:cobertura -Pjava8 -Pintegration
...
Java version: 1.8.0_112, vendor: Oracle Corporation
...
Running net.bytebuddy.agent.builder.LambdaFactoryTest
Tests run: 6, Failures: 1, Errors: 2, Skipped: 0, Time elapsed: 0.075 sec <<< FAILURE! - in net.bytebuddy.agent.builder.LambdaFactoryTest
testValidFactory(net.bytebuddy.agent.builder.LambdaFactoryTest)  Time elapsed: 0.017 sec  <<< ERROR!
java.lang.ExceptionInInitializerError
        at net.bytebuddy.agent.builder.LambdaFactoryTest.testValidFactory(LambdaFactoryTest.java:39)
Caused by: java.lang.NullPointerException
        at net.bytebuddy.agent.builder.LambdaFactoryTest.testValidFactory(LambdaFactoryTest.java:39)
```
Which are surprisingly do not cause termination of build.

In terms of impact on execution time:
```
$ time mvn clean package -Pjava7 -Pintegration
real    1m5.592s
user    2m24.768s
sys     0m2.997s

$ time mvn jacoco:prepare-agent clean package jacoco:report -Pjava7 -Pintegration
real    1m17.666s
user    3m2.385s
sys     0m3.172s

$ time mvn clean package -Pjava8 -Pintegration
real    1m10.037s
user    3m48.317s
sys     0m3.632s

$ time mvn jacoco:prepare-agent clean package jacoco:report -Pjava8 -Pintegration
real    1m19.844s
user    4m22.638s
sys     0m4.005s

$ time mvn clean cobertura:cobertura -Pjava7 -Pintegration
real    1m51.927s
user    4m10.458s
sys     0m5.467s
```
Last run is incomplete - again as described in #229, but even despite incompleteness it is anyway slowest.
From the above - overhead on execution: JaCoCo around **13 - 20%**, Cobertura around **70%**.

Summarizing all the above points - IMO JaCoCo might easily be part of regular build. So that in `.travis.yml` instead of
```yml
script: mvn verify $TARGET -Pintegration -Dnet.bytebuddy.test.travis=true
after_success: mvn clean cobertura:cobertura coveralls:report -Pintegration
```
you probably can do
```yml
script: mvn jacoco:prepare-agent verify jacoco:report $TARGET -Pintegration -Dnet.bytebuddy.test.travis=true
after_success: mvn coveralls:report
```
and tests will be executed only once instead of two times, reducing overall build time.

And speaking about results - while there are some small differences, overall they are pretty similar.