### PR TITLE
Update JaCoCo to 0.7.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <version.plugin.pitest>1.1.10</version.plugin.pitest>
         <version.plugin.animal-sniffer>1.14</version.plugin.animal-sniffer>
         <version.plugin.enforcer>1.4.1</version.plugin.enforcer>
-        <version.plugin.jacoco>0.7.7.201606060606</version.plugin.jacoco>
+        <version.plugin.jacoco>0.7.8</version.plugin.jacoco>
         <version.plugin.coveralls>4.1.0</version.plugin.coveralls>
         <version.plugin.checkstyle>2.17</version.plugin.checkstyle>
         <version.plugin.findbugs>3.0.3</version.plugin.findbugs>


### PR DESCRIPTION
It was released yesterday - https://github.com/jacoco/jacoco/releases/tag/v0.7.8
And I was slower with update for #230 than you with merge as usual :laughing: 

As of today it doesn't bring much here, just to keep things up-to-date.
But will be useful, if you'll start testing JDK 9 EA :wink: 
