### PR TITLE
Prevent redefining 0 types in resubmission

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/agent/builder/AgentBuilder.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/agent/builder/AgentBuilder.java
@@ -5061,14 +5061,16 @@ public interface AgentBuilder {
                                     entries.remove();
                                 }
                             }
-                            RedefinitionStrategy.Collector collector = redefinitionStrategy.make();
-                            collector.include(types);
-                            collector.apply(instrumentation,
-                                    circularityLock,
-                                    locationStrategy,
-                                    listener,
-                                    redefinitionBatchAllocator,
-                                    redefinitionBatchListener);
+                            if (!types.isEmpty()) {
+                                RedefinitionStrategy.Collector collector = redefinitionStrategy.make();
+                                collector.include(types);
+                                collector.apply(instrumentation,
+                                        circularityLock,
+                                        locationStrategy,
+                                        listener,
+                                        redefinitionBatchAllocator,
+                                        redefinitionBatchListener);
+                            }
 
                         } finally {
                             if (release) {


### PR DESCRIPTION
This will prevent the message "Redefined 0 types in 0 batches"