### PR TITLE
Fix broken build plugins with failing tests

### DIFF
--- a/byte-buddy-gradle-plugin/src/main/java/net/bytebuddy/build/gradle/TransformationAction.java
+++ b/byte-buddy-gradle-plugin/src/main/java/net/bytebuddy/build/gradle/TransformationAction.java
@@ -211,7 +211,7 @@ public class TransformationAction implements Action<Task> {
                                   ClassFileLocator classFileLocator,
                                   TypePool typePool,
                                   List<Plugin> plugins) {
-        String typeName = file.replace(File.separatorChar, '.').substring(0, file.length() - CLASS_FILE_EXTENSION.length());
+        String typeName = file.replace('/', '.').substring(0, file.length() - CLASS_FILE_EXTENSION.length());
         project.getLogger().debug("Processing class file: {}", typeName);
         TypeDescription typeDescription = typePool.describe(typeName).resolve();
         DynamicType.Builder<?> builder;

--- a/byte-buddy-maven-plugin/src/main/java/net/bytebuddy/build/maven/ByteBuddyMojo.java
+++ b/byte-buddy-maven-plugin/src/main/java/net/bytebuddy/build/maven/ByteBuddyMojo.java
@@ -317,7 +317,7 @@ public abstract class ByteBuddyMojo extends AbstractMojo {
                                   ClassFileLocator classFileLocator,
                                   TypePool typePool,
                                   List<Plugin> plugins) throws MojoExecutionException, MojoFailureException {
-        String typeName = file.replace(File.separatorChar, '.').substring(0, file.length() - CLASS_FILE_EXTENSION.length());
+        String typeName = file.replace('/', '.').substring(0, file.length() - CLASS_FILE_EXTENSION.length());
         getLog().debug("Processing class file: " + typeName);
         TypeDescription typeDescription = typePool.describe(typeName).resolve();
         DynamicType.Builder<?> builder;


### PR DESCRIPTION
This fixes java.lang.IllegalArgumentException: foo/Bar contains the illegal character '/' (on Windows). 'file' is a relativized URI#toString(), not File#toString(), therefore the separator character will be '/' on any platform (including Windows).