### PR TITLE
Use wildcard in Advice.WithCustomMapping#bind

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/asm/Advice.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/asm/Advice.java
@@ -8553,7 +8553,6 @@ public class Advice implements AsmVisitorWrapper.ForDeclaredMethods.MethodVisito
          * a parameter of an advice method, the dynamic value is asked to provide a value that is then assigned to the parameter in question.
          *
          * @param offsetMapping The dynamic value that is computed for binding the parameter to a value.
-         * @param <T>           The annotation type.
          * @return A new builder for an advice that considers the supplied annotation type during binding.
          */
         public WithCustomMapping bind(OffsetMapping.Factory<?> offsetMapping) {

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/asm/Advice.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/asm/Advice.java
@@ -8556,7 +8556,7 @@ public class Advice implements AsmVisitorWrapper.ForDeclaredMethods.MethodVisito
          * @param <T>           The annotation type.
          * @return A new builder for an advice that considers the supplied annotation type during binding.
          */
-        public <T extends Annotation> WithCustomMapping bind(OffsetMapping.Factory<? super T> offsetMapping) {
+        public WithCustomMapping bind(OffsetMapping.Factory<?> offsetMapping) {
             Map<Class<? extends Annotation>, OffsetMapping.Factory<?>> offsetMappings = new HashMap<Class<? extends Annotation>, OffsetMapping.Factory<?>>(this.offsetMappings);
             if (!offsetMapping.getAnnotationType().isAnnotation()) {
                 throw new IllegalArgumentException("Not an annotation type: " + offsetMapping.getAnnotationType());


### PR DESCRIPTION
I think `OffsetMapping.Factory<? extends Annotation>` would be redundant as the generic parameter T can only extend Annotation because of the interface declaration `interface Factory<T extends Annotation>`. Also, the generic type parameter is not important in the method. That's why I went for `OffsetMapping.Factory<?>`.