### PR TITLE
Release the restriction about one method not allow to have two same e…

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/dynamic/scaffold/InstrumentedType.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/dynamic/scaffold/InstrumentedType.java
@@ -944,11 +944,8 @@ public interface InstrumentedType extends TypeDescription {
                         }
                     }
                 }
-                Set<TypeDescription.Generic> exceptionTypes = new HashSet<Generic>();
                 for (TypeDescription.Generic exceptionType : methodDescription.getExceptionTypes()) {
-                    if (!exceptionTypes.add(exceptionType)) {
-                        throw new IllegalStateException("Duplicate exception type " + exceptionType + " for " + methodDescription);
-                    } else if (!exceptionType.accept(Generic.Visitor.Validator.EXCEPTION)) {
+                    if (!exceptionType.accept(Generic.Visitor.Validator.EXCEPTION)) {
                         throw new IllegalStateException("Illegal exception type " + exceptionType + " for " + methodDescription);
                     } else if (!exceptionType.accept(Generic.Visitor.Validator.ForTypeAnnotations.INSTANCE)) {
                         throw new IllegalStateException("Illegal type annotations on " + exceptionType + " for " + methodDescription);


### PR DESCRIPTION
Hi, my friend:
I find a small question in byte-buddy when I use it to instrument memcache.
the following method in {net.rubyeye.xmemcached.XMemcachedClient} has two {MemcachedException}. 

```
@SuppressWarnings("unchecked")
private final <T> Object fetch0(final String key, final byte[] keyBytes,
final CommandType cmdType, final long timeout,
Transcoder<T> transcoder) throws InterruptedException,
TimeoutException, MemcachedException, MemcachedException {
```

But in byte-buddy {net.bytebuddy.dynamic.scaffold.InstrumentedType}, there are following code to forbid one method have two same exception.

```
Set<TypeDescription.Generic> exceptionTypes = new HashSet<Generic>();
for (TypeDescription.Generic exceptionType : methodDescription.getExceptionTypes()) {
    if (!exceptionTypes.add(exceptionType)) {
    throw new IllegalStateException("Duplicate exception type " + exceptionType + " for " + methodDescription);
    } else if (!exceptionType.accept(Generic.Visitor.Validator.EXCEPTION)) {
    throw new IllegalStateException("Illegal exception type " + exceptionType + " for " + methodDescription);
    } else if (!exceptionType.accept(Generic.Visitor.Validator.ForTypeAnnotations.INSTANCE)) {
    throw new IllegalStateException("Illegal type annotations on " + exceptionType + " for " + methodDescription);
    } else if (!methodDescription.isSynthetic() && !exceptionType.asErasure().isVisibleTo(this)) {
    throw new IllegalStateException("Invisible exception type " + exceptionType + " for " + methodDescription);
    }
}
```
I do not know that does this work in any particular way? Or have special role, 
if not,  I hope byte-buddy can get optimized to obtain better development. Thank you very much!