### PR TITLE
Add Jackson to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ making Byte Buddy the success it has become. We really appreciate it!
 
 ___
 
-Byte Buddy offers excellent performance at production quality. It is stable and in use by distiguished frameworks and tools such as [Mockito](http://mockito.org), [Hibernate](http://hibernate.org), [Google's Bazel build system](http://bazel.io) and [many others](https://github.com/raphw/byte-buddy/wiki/Projects-using-Byte-Buddy). Byte Buddy is also used by a large number of commercial products to great result. It is currently downloaded over a million times a year.
+Byte Buddy offers excellent performance at production quality. It is stable and in use by distiguished frameworks and tools such as [Mockito](http://mockito.org), [Hibernate](http://hibernate.org), [Jackson](https://github.com/FasterXML/jackson), [Google's Bazel build system](http://bazel.io) and [many others](https://github.com/raphw/byte-buddy/wiki/Projects-using-Byte-Buddy). Byte Buddy is also used by a large number of commercial products to great result. It is currently downloaded over a million times a year.
 
 Hello World
 -----------


### PR DESCRIPTION
ByteBuddy support has been added to the master branch of Jackson, and is slated to replace the ASM codegen portions with upcoming 3.0.0 Release.

Details can be found in [this](https://github.com/FasterXML/jackson-modules-base/pull/28) and [this](https://github.com/FasterXML/jackson-modules-base/pull/29) PR.