### PR TITLE
Upgrade to JDK 10 General-Availability Release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
       install: echo "The default Travis install script is being skipped!"
 # Java 10
     - env: JDK='JDK 10' TARGET='-Pjava10'
-      install: . ./install-jdk.sh -F 10 -L BCL
+      install: . ./install-jdk.sh -F 10 -L GPL
 # Java 11
     - env: JDK='JDK 11' TARGET='-Pjava11'
       install: . ./install-jdk.sh -F 11 -L BCL


### PR DESCRIPTION
As Oracle JDK 10 is no longer available from http://jdk.java.net/10/ the license option is flipped from `BCL` to `GPL`. Travis CI does not yet provide an Oracle JDK 10 installation. See https://github.com/travis-ci/travis-ci/issues/9368 for details.