### PR TITLE
Reduce memory allocation for ArrayProjection.getName()

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/description/type/TypeDescription.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/description/type/TypeDescription.java
@@ -7463,11 +7463,20 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
 
         @Override
         public String getName() {
-            StringBuilder stringBuilder = new StringBuilder();
+            String descriptor = componentType.getDescriptor();
+            StringBuilder stringBuilder = new StringBuilder(descriptor.length() + arity);
             for (int i = 0; i < arity; i++) {
                 stringBuilder.append('[');
             }
-            return stringBuilder.append(componentType.getDescriptor().replace('/', '.')).toString();
+            for (int i = 0; i < descriptor.length(); i++) {
+                char ch = descriptor.charAt(i);
+                if (ch == '/') {
+                    stringBuilder.append('.');
+                } else {
+                    stringBuilder.append(ch);
+                }
+            }
+            return stringBuilder.toString();
         }
 
         @Override


### PR DESCRIPTION
ArrayProjection.getName() allocates a few extra objects. 
This change eliminates most of them by pre-allocate
the exact StringBuilder size and perform the replacement
manually instead.