### PR TITLE
Add TypeDescription.ForLoadedType.of which will return an instance of

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/asm/Advice.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/asm/Advice.java
@@ -3122,28 +3122,28 @@ public class Advice implements AsmVisitorWrapper.ForDeclaredMethods.MethodVisito
                         return new OfDefaultValue<S>(annotationType);
                     } else if (value instanceof Boolean) {
                         stackManipulation = IntegerConstant.forValue((Boolean) value);
-                        typeDescription = new TypeDescription.ForLoadedType(boolean.class);
+                        typeDescription = TypeDescription.BOOLEAN_PRIMITIVE;
                     } else if (value instanceof Byte) {
                         stackManipulation = IntegerConstant.forValue((Byte) value);
-                        typeDescription = new TypeDescription.ForLoadedType(byte.class);
+                        typeDescription = TypeDescription.BYTE_PRIMITIVE;
                     } else if (value instanceof Short) {
                         stackManipulation = IntegerConstant.forValue((Short) value);
-                        typeDescription = new TypeDescription.ForLoadedType(short.class);
+                        typeDescription = TypeDescription.SHORT_PRIMITIVE;
                     } else if (value instanceof Character) {
                         stackManipulation = IntegerConstant.forValue((Character) value);
-                        typeDescription = new TypeDescription.ForLoadedType(char.class);
+                        typeDescription = TypeDescription.CHARACTER_PRIMITIVE;
                     } else if (value instanceof Integer) {
                         stackManipulation = IntegerConstant.forValue((Integer) value);
-                        typeDescription = new TypeDescription.ForLoadedType(int.class);
+                        typeDescription = TypeDescription.INTEGER_PRIMITIVE;
                     } else if (value instanceof Long) {
                         stackManipulation = LongConstant.forValue((Long) value);
-                        typeDescription = new TypeDescription.ForLoadedType(long.class);
+                        typeDescription = TypeDescription.LONG_PRIMITIVE;
                     } else if (value instanceof Float) {
                         stackManipulation = FloatConstant.forValue((Float) value);
-                        typeDescription = new TypeDescription.ForLoadedType(float.class);
+                        typeDescription = TypeDescription.FLOAT_PRIMITIVE;
                     } else if (value instanceof Double) {
                         stackManipulation = DoubleConstant.forValue((Double) value);
-                        typeDescription = new TypeDescription.ForLoadedType(double.class);
+                        typeDescription = TypeDescription.DOUBLE_PRIMITIVE;
                     } else if (value instanceof String) {
                         stackManipulation = new TextConstant((String) value);
                         typeDescription = TypeDescription.STRING;

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/description/field/FieldDescription.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/description/field/FieldDescription.java
@@ -227,7 +227,7 @@ public interface FieldDescription extends ByteCodeElement,
 
         @Override
         public TypeDescription getDeclaringType() {
-            return new TypeDescription.ForLoadedType(field.getDeclaringClass());
+            return TypeDescription.ForLoadedType.of(field.getDeclaringClass());
         }
 
         @Override

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/description/type/TypeDescription.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/description/type/TypeDescription.java
@@ -68,6 +68,86 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
     TypeDescription VOID = new ForLoadedType(void.class);
 
     /**
+     * A representation of the {@code Integer} non-type.
+     */
+    TypeDescription INTEGER = new ForLoadedType(Integer.class);
+
+    /**
+     * A representation of the {@code Long} non-type.
+     */
+    TypeDescription LONG = new ForLoadedType(Long.class);
+
+    /**
+     * A representation of the {@code Short} non-type.
+     */
+    TypeDescription SHORT = new ForLoadedType(Short.class);
+
+    /**
+     * A representation of the {@code Byte} non-type.
+     */
+    TypeDescription BYTE = new ForLoadedType(Byte.class);
+
+    /**
+     * A representation of the {@code Character} non-type.
+     */
+    TypeDescription CHARACTER = new ForLoadedType(Character.class);
+
+    /**
+     * A representation of the {@code Double} non-type.
+     */
+    TypeDescription DOUBLE = new ForLoadedType(Double.class);
+
+    /**
+     * A representation of the {@code Float} non-type.
+     */
+    TypeDescription FLOAT = new ForLoadedType(Float.class);
+
+    /**
+     * A representation of the {@code Boolean} non-type.
+     */
+    TypeDescription BOOLEAN = new ForLoadedType(Boolean.class);
+
+    /**
+     * A representation of the {@code int} non-type.
+     */
+    TypeDescription INTEGER_PRIMITIVE = new ForLoadedType(int.class);
+
+    /**
+     * A representation of the {@code long} non-type.
+     */
+    TypeDescription LONG_PRIMITIVE = new ForLoadedType(long.class);
+
+    /**
+     * A representation of the {@code short} non-type.
+     */
+    TypeDescription SHORT_PRIMITIVE = new ForLoadedType(short.class);
+
+    /**
+     * A representation of the {@code byte} non-type.
+     */
+    TypeDescription BYTE_PRIMITIVE = new ForLoadedType(byte.class);
+
+    /**
+     * A representation of the {@code char} non-type.
+     */
+    TypeDescription CHARACTER_PRIMITIVE = new ForLoadedType(char.class);
+
+    /**
+     * A representation of the {@code double} non-type.
+     */
+    TypeDescription DOUBLE_PRIMITIVE = new ForLoadedType(double.class);
+
+    /**
+     * A representation of the {@code float} non-type.
+     */
+    TypeDescription FLOAT_PRIMITIVE = new ForLoadedType(float.class);
+
+    /**
+     * A representation of the {@code boolean} non-type.
+     */
+    TypeDescription BOOLEAN_PRIMITIVE = new ForLoadedType(boolean.class);
+
+    /**
      * A list of interfaces that are implicitly implemented by any array type.
      */
     TypeList.Generic ARRAY_INTERFACES = new TypeList.Generic.ForLoadedTypes(Cloneable.class, Serializable.class);
@@ -323,6 +403,47 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
      * @return This types default value.
      */
     Object getDefaultValue();
+
+    /**
+     * A cache for often used {@link TypeDescription} to reduce memory allocation.
+     */
+    final class TypeCache {
+
+        /**
+         * Map from Type to TypeDescription.
+         */
+        static final Map<java.lang.reflect.Type, TypeDescription> WELLKNOWN_TYPE_MAP;
+
+        static {
+            WELLKNOWN_TYPE_MAP = new HashMap<java.lang.reflect.Type, TypeDescription>(20);
+            WELLKNOWN_TYPE_MAP.put(Integer.class, INTEGER);
+            WELLKNOWN_TYPE_MAP.put(Long.class, LONG);
+            WELLKNOWN_TYPE_MAP.put(Short.class, SHORT);
+            WELLKNOWN_TYPE_MAP.put(Character.class, CHARACTER);
+            WELLKNOWN_TYPE_MAP.put(Byte.class, BYTE);
+            WELLKNOWN_TYPE_MAP.put(Float.class, FLOAT);
+            WELLKNOWN_TYPE_MAP.put(Double.class, DOUBLE);
+            WELLKNOWN_TYPE_MAP.put(Boolean.class, BOOLEAN);
+            WELLKNOWN_TYPE_MAP.put(int.class, INTEGER_PRIMITIVE);
+            WELLKNOWN_TYPE_MAP.put(long.class, LONG_PRIMITIVE);
+            WELLKNOWN_TYPE_MAP.put(short.class, SHORT_PRIMITIVE);
+            WELLKNOWN_TYPE_MAP.put(char.class, CHARACTER_PRIMITIVE);
+            WELLKNOWN_TYPE_MAP.put(byte.class, BYTE_PRIMITIVE);
+            WELLKNOWN_TYPE_MAP.put(float.class, FLOAT_PRIMITIVE);
+            WELLKNOWN_TYPE_MAP.put(double.class, DOUBLE_PRIMITIVE);
+            WELLKNOWN_TYPE_MAP.put(boolean.class, BOOLEAN_PRIMITIVE);
+            WELLKNOWN_TYPE_MAP.put(void.class, VOID);
+            WELLKNOWN_TYPE_MAP.put(String.class, STRING);
+            WELLKNOWN_TYPE_MAP.put(Object.class, OBJECT);
+        }
+
+        /**
+         * TypeCache cannot be instantiated.
+         */
+        private TypeCache() {
+            throw new UnsupportedOperationException("Cannot create a compound list");
+        }
+    }
 
     /**
      * <p>
@@ -3364,7 +3485,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
 
                 @Override
                 public TypeDescription asErasure() {
-                    return new TypeDescription.ForLoadedType(type);
+                    return TypeDescription.ForLoadedType.of(type);
                 }
 
                 @Override
@@ -5015,7 +5136,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
                 public TypeVariableSource getTypeVariableSource() {
                     GenericDeclaration genericDeclaration = typeVariable.getGenericDeclaration();
                     if (genericDeclaration instanceof Class) {
-                        return new TypeDescription.ForLoadedType((Class<?>) genericDeclaration);
+                        return TypeDescription.ForLoadedType.of((Class<?>) genericDeclaration);
                     } else if (genericDeclaration instanceof Method) {
                         return new MethodDescription.ForLoadedMethod((Method) genericDeclaration);
                     } else if (genericDeclaration instanceof Constructor) {
@@ -5501,7 +5622,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
                     Class<?> superClass = type.getSuperclass();
                     return superClass == null
                             ? TypeDescription.UNDEFINED
-                            : new ForLoadedType(superClass);
+                            : ForLoadedType.of(superClass);
                 }
 
                 @Override
@@ -5536,7 +5657,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
 
                 @Override
                 public TypeDescription asErasure() {
-                    return new ForLoadedType(field.getType());
+                    return ForLoadedType.of(field.getType());
                 }
 
                 @Override
@@ -5571,7 +5692,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
 
                 @Override
                 public TypeDescription asErasure() {
-                    return new ForLoadedType(method.getReturnType());
+                    return ForLoadedType.of(method.getReturnType());
                 }
 
                 @Override
@@ -5624,7 +5745,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
 
                 @Override
                 public TypeDescription asErasure() {
-                    return new TypeDescription.ForLoadedType(erasure[index]);
+                    return TypeDescription.ForLoadedType.of(erasure[index]);
                 }
 
                 @Override
@@ -5677,7 +5798,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
 
                 @Override
                 public TypeDescription asErasure() {
-                    return new TypeDescription.ForLoadedType(erasure[index]);
+                    return TypeDescription.ForLoadedType.of(erasure[index]);
                 }
 
                 @Override
@@ -5778,7 +5899,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
              * @return A builder for creating a raw type.
              */
             public static Builder rawType(Class<?> type) {
-                return rawType(new ForLoadedType(type));
+                return rawType(ForLoadedType.of(type));
             }
 
             /**
@@ -5799,7 +5920,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
              * @return A builder for creating a raw type.
              */
             public static Builder rawType(Class<?> type, Generic ownerType) {
-                return rawType(new ForLoadedType(type), ownerType);
+                return rawType(ForLoadedType.of(type), ownerType);
             }
 
             /**
@@ -5909,7 +6030,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
              * @return A builder for creating a parameterized type.
              */
             public static Builder parameterizedType(Class<?> rawType, java.lang.reflect.Type ownerType, List<? extends java.lang.reflect.Type> parameters) {
-                return parameterizedType(new ForLoadedType(rawType),
+                return parameterizedType(ForLoadedType.of(rawType),
                         ownerType == null
                                 ? null
                                 : Sort.describe(ownerType),
@@ -6481,7 +6602,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
 
         @Override
         public boolean isAssignableFrom(Class<?> type) {
-            return isAssignableFrom(new ForLoadedType(type));
+            return isAssignableFrom(ForLoadedType.of(type));
         }
 
         @Override
@@ -6491,7 +6612,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
 
         @Override
         public boolean isAssignableTo(Class<?> type) {
-            return isAssignableTo(new ForLoadedType(type));
+            return isAssignableTo(ForLoadedType.of(type));
         }
 
         @Override
@@ -6781,21 +6902,21 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
         @Override
         public TypeDescription asBoxed() {
             if (represents(boolean.class)) {
-                return new ForLoadedType(Boolean.class);
+                return BOOLEAN;
             } else if (represents(byte.class)) {
-                return new ForLoadedType(Byte.class);
+                return BYTE;
             } else if (represents(short.class)) {
-                return new ForLoadedType(Short.class);
+                return SHORT;
             } else if (represents(char.class)) {
-                return new ForLoadedType(Character.class);
+                return CHARACTER;
             } else if (represents(int.class)) {
-                return new ForLoadedType(Integer.class);
+                return INTEGER;
             } else if (represents(long.class)) {
-                return new ForLoadedType(Long.class);
+                return LONG;
             } else if (represents(float.class)) {
-                return new ForLoadedType(Float.class);
+                return FLOAT;
             } else if (represents(double.class)) {
-                return new ForLoadedType(Double.class);
+                return DOUBLE;
             } else {
                 return this;
             }
@@ -6804,21 +6925,21 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
         @Override
         public TypeDescription asUnboxed() {
             if (represents(Boolean.class)) {
-                return new ForLoadedType(boolean.class);
+                return BOOLEAN_PRIMITIVE;
             } else if (represents(Byte.class)) {
-                return new ForLoadedType(byte.class);
+                return BYTE_PRIMITIVE;
             } else if (represents(Short.class)) {
-                return new ForLoadedType(short.class);
+                return SHORT_PRIMITIVE;
             } else if (represents(Character.class)) {
-                return new ForLoadedType(char.class);
+                return CHARACTER_PRIMITIVE;
             } else if (represents(Integer.class)) {
-                return new ForLoadedType(int.class);
+                return INTEGER_PRIMITIVE;
             } else if (represents(Long.class)) {
-                return new ForLoadedType(long.class);
+                return LONG_PRIMITIVE;
             } else if (represents(Float.class)) {
-                return new ForLoadedType(float.class);
+                return FLOAT_PRIMITIVE;
             } else if (represents(Double.class)) {
-                return new ForLoadedType(double.class);
+                return DOUBLE_PRIMITIVE;
             } else {
                 return this;
             }
@@ -7043,7 +7164,6 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
      * A type description implementation that represents a loaded type.
      */
     class ForLoadedType extends AbstractBase implements Serializable {
-
         /**
          * The class's serial version UID.
          */
@@ -7079,6 +7199,20 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
                     : name.substring(0, anonymousLoaderIndex);
         }
 
+        /**
+         * Returns a new immutable type description for a loaded type.
+         *
+         * @param type The type to be represented by this type description.
+         * @return the type description representing the given type.
+         */
+        public static TypeDescription of(Class<?> type) {
+            TypeDescription res = TypeDescription.TypeCache.WELLKNOWN_TYPE_MAP.get(type);
+            if (res != null) {
+                return res;
+            }
+            return new ForLoadedType(type);
+        }
+
         @Override
         public boolean isAssignableFrom(Class<?> type) {
             // The JVM conducts more efficient assignability lookups of loaded types what is attempted first.
@@ -7102,7 +7236,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
             Class<?> componentType = type.getComponentType();
             return componentType == null
                     ? TypeDescription.UNDEFINED
-                    : new ForLoadedType(componentType);
+                    : ForLoadedType.of(componentType);
         }
 
         @Override
@@ -7149,7 +7283,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
             Class<?> declaringType = type.getDeclaringClass();
             return declaringType == null
                     ? TypeDescription.UNDEFINED
-                    : new ForLoadedType(declaringType);
+                    : ForLoadedType.of(declaringType);
         }
 
         @Override
@@ -7170,7 +7304,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
             Class<?> enclosingType = type.getEnclosingClass();
             return enclosingType == null
                     ? TypeDescription.UNDEFINED
-                    : new ForLoadedType(enclosingType);
+                    : ForLoadedType.of(enclosingType);
         }
 
         @Override
@@ -7977,7 +8111,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
             @Override
             public TypeDescription asErasure() {
                 try {
-                    return new ForLoadedType(classLoadingDelegate.load(delegate.asErasure().getName(), classLoader));
+                    return ForLoadedType.of(classLoadingDelegate.load(delegate.asErasure().getName(), classLoader));
                 } catch (ClassNotFoundException ignored) {
                     return delegate.asErasure();
                 }

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/description/type/TypeList.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/description/type/TypeList.java
@@ -91,7 +91,7 @@ public interface TypeList extends FilterableList<TypeDescription, TypeList> {
 
         @Override
         public TypeDescription get(int index) {
-            return new TypeDescription.ForLoadedType(types.get(index));
+            return TypeDescription.ForLoadedType.of(types.get(index));
         }
 
         @Override
@@ -718,7 +718,7 @@ public interface TypeList extends FilterableList<TypeDescription, TypeList> {
 
                 @Override
                 public TypeDescription asErasure() {
-                    return new TypeDescription.ForLoadedType(erasure[index]);
+                    return TypeDescription.ForLoadedType.of(erasure[index]);
                 }
 
                 @Override
@@ -805,7 +805,7 @@ public interface TypeList extends FilterableList<TypeDescription, TypeList> {
 
                 @Override
                 public TypeDescription asErasure() {
-                    return new TypeDescription.ForLoadedType(erasure[index]);
+                    return TypeDescription.ForLoadedType.of(erasure[index]);
                 }
 
                 @Override
@@ -892,7 +892,7 @@ public interface TypeList extends FilterableList<TypeDescription, TypeList> {
 
                 @Override
                 public TypeDescription asErasure() {
-                    return new TypeDescription.ForLoadedType(erasure[index]);
+                    return TypeDescription.ForLoadedType.of(erasure[index]);
                 }
 
                 @Override

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/EqualsMethod.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/EqualsMethod.java
@@ -40,7 +40,7 @@ public class EqualsMethod implements Implementation {
     /**
      * The {@link Object#equals(Object)} method.
      */
-    private static final MethodDescription.InDefinedShape EQUALS = new TypeDescription.ForLoadedType(Object.class)
+    private static final MethodDescription.InDefinedShape EQUALS = TypeDescription.OBJECT
             .getDeclaredMethods()
             .filter(isEquals())
             .getOnly();

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/FieldAccessor.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/FieldAccessor.java
@@ -511,7 +511,7 @@ public abstract class FieldAccessor implements Implementation {
 
         @Override
         public AssignerConfigurable in(Class<?> type) {
-            return in(new TypeDescription.ForLoadedType(type));
+            return in(TypeDescription.ForLoadedType.of(type));
         }
 
         @Override

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/bytecode/assign/primitive/PrimitiveBoxingDelegate.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/bytecode/assign/primitive/PrimitiveBoxingDelegate.java
@@ -86,7 +86,7 @@ public enum PrimitiveBoxingDelegate {
                             StackSize sizeDifference,
                             String boxingMethodName,
                             String boxingMethodDescriptor) {
-        this.wrapperType = new TypeDescription.ForLoadedType(wrapperType);
+        this.wrapperType = TypeDescription.ForLoadedType.of(wrapperType);
         this.size = sizeDifference.toDecreasingSize();
         this.boxingMethodName = boxingMethodName;
         this.boxingMethodDescriptor = boxingMethodDescriptor;

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/bytecode/assign/primitive/PrimitiveUnboxingDelegate.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/bytecode/assign/primitive/PrimitiveUnboxingDelegate.java
@@ -95,8 +95,8 @@ public enum PrimitiveUnboxingDelegate implements StackManipulation {
                               String unboxingMethodName,
                               String unboxingMethodDescriptor) {
         this.size = sizeDifference.toIncreasingSize();
-        this.wrapperType = new TypeDescription.ForLoadedType(wrapperType);
-        this.primitiveType = new TypeDescription.ForLoadedType(primitiveType);
+        this.wrapperType = TypeDescription.ForLoadedType.of(wrapperType);
+        this.primitiveType = TypeDescription.ForLoadedType.of(primitiveType);
         this.unboxingMethodName = unboxingMethodName;
         this.unboxingMethodDescriptor = unboxingMethodDescriptor;
     }

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/pool/TypePool.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/pool/TypePool.java
@@ -1,5 +1,24 @@
 package net.bytebuddy.pool;
 
+import static net.bytebuddy.matcher.ElementMatchers.hasDescriptor;
+import static net.bytebuddy.matcher.ElementMatchers.hasMethodName;
+import static net.bytebuddy.matcher.ElementMatchers.is;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Array;
+import java.lang.reflect.GenericSignatureFormatError;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import net.bytebuddy.build.HashCodeAndEqualsPlugin;
 import net.bytebuddy.description.TypeVariableSource;
@@ -19,19 +38,18 @@ import net.bytebuddy.description.type.TypeList;
 import net.bytebuddy.dynamic.ClassFileLocator;
 import net.bytebuddy.implementation.bytecode.StackSize;
 import net.bytebuddy.utility.OpenedClassReader;
-import org.objectweb.asm.*;
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.TypePath;
+import org.objectweb.asm.TypeReference;
 import org.objectweb.asm.signature.SignatureReader;
 import org.objectweb.asm.signature.SignatureVisitor;
-
-import java.io.IOException;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Array;
-import java.lang.reflect.GenericSignatureFormatError;
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-
-import static net.bytebuddy.matcher.ElementMatchers.*;
 
 /**
  * A type pool allows the retrieval of {@link TypeDescription} by its name.
@@ -303,7 +321,7 @@ public interface TypePool {
                     float.class,
                     double.class,
                     void.class}) {
-                primitiveTypes.put(primitiveType.getName(), new TypeDescription.ForLoadedType(primitiveType));
+                primitiveTypes.put(primitiveType.getName(), TypeDescription.ForLoadedType.of(primitiveType));
                 primitiveDescriptors.put(Type.getDescriptor(primitiveType), primitiveType.getName());
             }
             PRIMITIVE_TYPES = Collections.unmodifiableMap(primitiveTypes);
@@ -3152,7 +3170,7 @@ public interface TypePool {
                      * @param type The loaded type representing this primitive.
                      */
                     ForPrimitiveType(Class<?> type) {
-                        typeDescription = new ForLoadedType(type);
+                        typeDescription = ForLoadedType.of(type);
                     }
 
                     /**


### PR DESCRIPTION
Add TypeDescription.ForLoadedType.of which will return an instance of well known type when possible to reduce memory allocation. We can convert most of the call to use this method instead of the constructor later.