### PR TITLE
Use much more efficient method to determine whether the class is a package-info class

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/description/type/TypeDescription.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/description/type/TypeDescription.java
@@ -6743,7 +6743,18 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
 
         @Override
         public boolean isPackageType() {
-            return getSimpleName().equals(PackageDescription.PACKAGE_CLASS_NAME);
+            String name = getName();
+
+            int nameLength = name.length();
+            int packageClassNameLength = PackageDescription.PACKAGE_CLASS_NAME.length();
+
+            if (nameLength < packageClassNameLength) {
+                return false;
+            }
+            if (nameLength > packageClassNameLength && name.charAt(nameLength - packageClassNameLength - 1) != '.') {
+                return false;
+            }
+            return name.endsWith(PackageDescription.PACKAGE_CLASS_NAME);
         }
 
         @Override


### PR DESCRIPTION
This is to optimize validated() method which will 
call into this method very often. As package-info string must 
be the end of full class name, we can optimize away the need to 
call String.indexOf/String.substring