### PR TITLE
Pass in the argument whenever possible to reduce the memory allocation...

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/description/annotation/AnnotationDescription.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/description/annotation/AnnotationDescription.java
@@ -317,7 +317,7 @@ public interface AnnotationDescription {
             try {
                 for (Map.Entry<Method, AnnotationValue.Loaded<?>> entry : values.entrySet()) {
                     try {
-                        if (!entry.getValue().represents(entry.getKey().invoke(other))) {
+                        if (!entry.getValue().represents(entry.getKey().invoke(other, (Object[]) null))) {
                             return false;
                         }
                     } catch (RuntimeException exception) {

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/description/method/ParameterDescription.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/description/method/ParameterDescription.java
@@ -343,7 +343,7 @@ public interface ParameterDescription extends AnnotationSource,
                 @Override
                 public int getModifiers(AccessibleObject executable, int index) {
                     try {
-                        return (Integer) getModifiers.invoke(getParameter(executable, index));
+                        return (Integer) getModifiers.invoke(getParameter(executable, index), (Object[]) null);
                     } catch (IllegalAccessException exception) {
                         throw new IllegalStateException("Cannot access java.lang.reflect.Parameter#getModifiers", exception);
                     } catch (InvocationTargetException exception) {
@@ -354,7 +354,7 @@ public interface ParameterDescription extends AnnotationSource,
                 @Override
                 public boolean isNamePresent(AccessibleObject executable, int index) {
                     try {
-                        return (Boolean) isNamePresent.invoke(getParameter(executable, index));
+                        return (Boolean) isNamePresent.invoke(getParameter(executable, index), (Object[]) null);
                     } catch (IllegalAccessException exception) {
                         throw new IllegalStateException("Cannot access java.lang.reflect.Parameter#isNamePresent", exception);
                     } catch (InvocationTargetException exception) {
@@ -365,7 +365,7 @@ public interface ParameterDescription extends AnnotationSource,
                 @Override
                 public String getName(AccessibleObject executable, int index) {
                     try {
-                        return (String) getName.invoke(getParameter(executable, index));
+                        return (String) getName.invoke(getParameter(executable, index), (Object[]) null);
                     } catch (IllegalAccessException exception) {
                         throw new IllegalStateException("Cannot access java.lang.reflect.Parameter#getName", exception);
                     } catch (InvocationTargetException exception) {
@@ -382,7 +382,7 @@ public interface ParameterDescription extends AnnotationSource,
                  */
                 private Object getParameter(AccessibleObject executable, int index) {
                     try {
-                        return Array.get(getParameters.invoke(executable), index);
+                        return Array.get(getParameters.invoke(executable, (Object[]) null), index);
                     } catch (IllegalAccessException exception) {
                         throw new IllegalStateException("Cannot access java.lang.reflect.Executable#getParameters", exception);
                     } catch (InvocationTargetException exception) {

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/description/method/ParameterList.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/description/method/ParameterList.java
@@ -256,7 +256,7 @@ public interface ParameterList<T extends ParameterDescription> extends Filterabl
                 @Override
                 public int getParameterCount(Object executable) {
                     try {
-                        return (Integer) getParameterCount.invoke(executable);
+                        return (Integer) getParameterCount.invoke(executable, (Object[]) null);
                     } catch (IllegalAccessException exception) {
                         throw new IllegalStateException("Cannot access java.lang.reflect.Parameter#getModifiers", exception);
                     } catch (InvocationTargetException exception) {

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/description/type/TypeDescription.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/description/type/TypeDescription.java
@@ -2393,7 +2393,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
                     @Override
                     public Generic resolveReceiverType(AccessibleObject executable) {
                         try {
-                            return resolve((AnnotatedElement) getAnnotatedReceiverType.invoke(executable));
+                            return resolve((AnnotatedElement) getAnnotatedReceiverType.invoke(executable, (Object[]) null));
                         } catch (IllegalAccessException exception) {
                             throw new IllegalStateException("Cannot access java.lang.reflect.Executable#getAnnotatedReceiverType", exception);
                         } catch (InvocationTargetException exception) {
@@ -2406,7 +2406,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
                         try {
                             return annotatedType == null
                                     ? UNDEFINED
-                                    : Sort.describe((java.lang.reflect.Type) getType.invoke(annotatedType), new Resolved(annotatedType));
+                                    : Sort.describe((java.lang.reflect.Type) getType.invoke(annotatedType, (Object[]) null), new Resolved(annotatedType));
                         } catch (IllegalAccessException exception) {
                             throw new IllegalStateException("Cannot access java.lang.reflect.AnnotatedType#getType", exception);
                         } catch (InvocationTargetException exception) {
@@ -2494,7 +2494,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
                         @Override
                         public AnnotatedElement resolve() {
                             try {
-                                return (AnnotatedElement) getAnnotatedSuperclass.invoke(type);
+                                return (AnnotatedElement) getAnnotatedSuperclass.invoke(type, (Object[]) null);
                             } catch (IllegalAccessException exception) {
                                 throw new IllegalStateException("Cannot access java.lang.Class#getAnnotatedSuperclass", exception);
                             } catch (InvocationTargetException exception) {
@@ -2565,7 +2565,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
                         @Override
                         public AnnotatedElement resolve() {
                             try {
-                                return (AnnotatedElement) getAnnotatedType.invoke(field);
+                                return (AnnotatedElement) getAnnotatedType.invoke(field, (Object[]) null);
                             } catch (IllegalAccessException exception) {
                                 throw new IllegalStateException("Cannot access java.lang.reflect.Field#getAnnotatedType", exception);
                             } catch (InvocationTargetException exception) {
@@ -2597,7 +2597,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
                         @Override
                         public AnnotatedElement resolve() {
                             try {
-                                return (AnnotatedElement) getAnnotatedReturnType.invoke(method);
+                                return (AnnotatedElement) getAnnotatedReturnType.invoke(method, (Object[]) null);
                             } catch (IllegalAccessException exception) {
                                 throw new IllegalStateException("Cannot access java.lang.reflect.Method#getAnnotatedReturnType", exception);
                             } catch (InvocationTargetException exception) {
@@ -2636,7 +2636,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
                         @Override
                         public AnnotatedElement resolve() {
                             try {
-                                return (AnnotatedElement) Array.get(getAnnotatedParameterTypes.invoke(executable), index);
+                                return (AnnotatedElement) Array.get(getAnnotatedParameterTypes.invoke(executable, (Object[]) null), index);
                             } catch (IllegalAccessException exception) {
                                 throw new IllegalStateException("Cannot access java.lang.reflect.Executable#getAnnotatedParameterTypes", exception);
                             } catch (InvocationTargetException exception) {
@@ -2675,7 +2675,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
                         @Override
                         public AnnotatedElement resolve() {
                             try {
-                                return (AnnotatedElement) Array.get(getAnnotatedExceptionTypes.invoke(executable), index);
+                                return (AnnotatedElement) Array.get(getAnnotatedExceptionTypes.invoke(executable, (Object[]) null), index);
                             } catch (IllegalAccessException exception) {
                                 throw new IllegalStateException("Cannot access java.lang.reflect.Executable#getAnnotatedExceptionTypes", exception);
                             } catch (InvocationTargetException exception) {
@@ -2893,7 +2893,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
                 @Override
                 protected AnnotatedElement resolve(AnnotatedElement annotatedElement) {
                     try {
-                        Object annotatedUpperBounds = GET_ANNOTATED_UPPER_BOUNDS.invoke(annotatedElement);
+                        Object annotatedUpperBounds = GET_ANNOTATED_UPPER_BOUNDS.invoke(annotatedElement, (Object[]) null);
                         return Array.getLength(annotatedUpperBounds) == 0 // Wildcards with a lower bound do not define annotations for their implicit upper bound.
                                 ? NoOp.INSTANCE
                                 : (AnnotatedElement) Array.get(annotatedUpperBounds, index);
@@ -2937,7 +2937,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
                 @Override
                 protected AnnotatedElement resolve(AnnotatedElement annotatedElement) {
                     try {
-                        return (AnnotatedElement) Array.get(GET_ANNOTATED_LOWER_BOUNDS.invoke(annotatedElement), index);
+                        return (AnnotatedElement) Array.get(GET_ANNOTATED_LOWER_BOUNDS.invoke(annotatedElement, (Object[]) null), index);
                     } catch (ClassCastException ignored) { // To avoid bug on early releases of Java 8.
                         return NoOp.INSTANCE;
                     } catch (IllegalAccessException exception) {
@@ -2978,7 +2978,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
                 @Override
                 protected AnnotatedElement resolve(AnnotatedElement annotatedElement) {
                     try {
-                        return (AnnotatedElement) Array.get(GET_ANNOTATED_BOUNDS.invoke(annotatedElement), index);
+                        return (AnnotatedElement) Array.get(GET_ANNOTATED_BOUNDS.invoke(annotatedElement, (Object[]) null), index);
                     } catch (ClassCastException ignored) { // To avoid bug on early releases of Java 8.
                         return NoOp.INSTANCE;
                     } catch (IllegalAccessException exception) {
@@ -3023,7 +3023,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
                     @Override
                     public AnnotatedElement resolve() {
                         try {
-                            return (AnnotatedElement) Array.get(GET_ANNOTATED_BOUNDS.invoke(typeVariable), index);
+                            return (AnnotatedElement) Array.get(GET_ANNOTATED_BOUNDS.invoke(typeVariable, (Object[]) null), index);
                         } catch (ClassCastException ignored) { // To avoid bug on early releases of Java 8.
                             return NoOp.INSTANCE;
                         } catch (IllegalAccessException exception) {
@@ -3065,7 +3065,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
                 @Override
                 protected AnnotatedElement resolve(AnnotatedElement annotatedElement) {
                     try {
-                        return (AnnotatedElement) Array.get(GET_ANNOTATED_ACTUAL_TYPE_ARGUMENTS.invoke(annotatedElement), index);
+                        return (AnnotatedElement) Array.get(GET_ANNOTATED_ACTUAL_TYPE_ARGUMENTS.invoke(annotatedElement, (Object[]) null), index);
                     } catch (ClassCastException ignored) { // To avoid bug on early releases of Java 8.
                         return NoOp.INSTANCE;
                     } catch (IllegalAccessException exception) {
@@ -3098,7 +3098,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
                 @Override
                 protected AnnotatedElement resolve(AnnotatedElement annotatedElement) {
                     try {
-                        return (AnnotatedElement) GET_ANNOTATED_GENERIC_COMPONENT_TYPE.invoke(annotatedElement);
+                        return (AnnotatedElement) GET_ANNOTATED_GENERIC_COMPONENT_TYPE.invoke(annotatedElement, (Object[]) null);
                     } catch (ClassCastException ignored) { // To avoid bug on early releases of Java 8.
                         return NoOp.INSTANCE;
                     } catch (IllegalAccessException exception) {
@@ -3145,7 +3145,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
                 @Override
                 protected AnnotatedElement resolve(AnnotatedElement annotatedElement) {
                     try {
-                        AnnotatedElement annotatedOwnerType = (AnnotatedElement) GET_ANNOTATED_OWNER_TYPE.invoke(annotatedElement);
+                        AnnotatedElement annotatedOwnerType = (AnnotatedElement) GET_ANNOTATED_OWNER_TYPE.invoke(annotatedElement, (Object[]) null);
                         return annotatedOwnerType == null
                                 ? NoOp.INSTANCE
                                 : annotatedOwnerType;

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/dynamic/ClassFileLocator.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/dynamic/ClassFileLocator.java
@@ -444,7 +444,7 @@ public interface ClassFileLocator extends Closeable {
                 Method getPackages = JavaType.MODULE.load().getMethod("getPackages");
                 for (Object rawModule : (Set<?>) layerType.getMethod("modules").invoke(layerType.getMethod("boot").invoke(null))) {
                     ClassFileLocator classFileLocator = ForModule.of(JavaModule.of(rawModule));
-                    for (Object packageName : (Set<?>) getPackages.invoke(rawModule)) {
+                    for (Object packageName : (Set<?>) getPackages.invoke(rawModule, (Object[]) null)) {
                         bootModules.put((String) packageName, classFileLocator);
                     }
                 }

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/dynamic/loading/ClassInjector.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/dynamic/loading/ClassInjector.java
@@ -1113,7 +1113,7 @@ public interface ClassInjector {
                 @Override
                 public Class<?> lookupType(Object lookup) {
                     try {
-                        return (Class<?>) lookupClass.invoke(lookup);
+                        return (Class<?>) lookupClass.invoke(lookup, (Object[]) null);
                     } catch (IllegalAccessException exception) {
                         throw new IllegalStateException("Cannot access java.lang.invoke.MethodHandles$Lookup#lookupClass", exception);
                     } catch (InvocationTargetException exception) {
@@ -1124,7 +1124,7 @@ public interface ClassInjector {
                 @Override
                 public int lookupModes(Object lookup) {
                     try {
-                        return (Integer) lookupModes.invoke(lookup);
+                        return (Integer) lookupModes.invoke(lookup, (Object[]) null);
                     } catch (IllegalAccessException exception) {
                         throw new IllegalStateException("Cannot access java.lang.invoke.MethodHandles$Lookup#lookupModes", exception);
                     } catch (InvocationTargetException exception) {

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/utility/JavaConstant.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/utility/JavaConstant.java
@@ -358,7 +358,7 @@ public interface JavaConstant {
                 @Override
                 public Class<?> returnType(Object methodType) {
                     try {
-                        return (Class<?>) returnType.invoke(methodType);
+                        return (Class<?>) returnType.invoke(methodType, (Object[]) null);
                     } catch (IllegalAccessException exception) {
                         throw new IllegalStateException("Cannot access java.lang.invoke.MethodType#returnType", exception);
                     } catch (InvocationTargetException exception) {
@@ -369,7 +369,7 @@ public interface JavaConstant {
                 @Override
                 public Class<?>[] parameterArray(Object methodType) {
                     try {
-                        return (Class<?>[]) parameterArray.invoke(methodType);
+                        return (Class<?>[]) parameterArray.invoke(methodType, (Object[]) null);
                     } catch (IllegalAccessException exception) {
                         throw new IllegalStateException("Cannot access java.lang.invoke.MethodType#parameterArray", exception);
                     } catch (InvocationTargetException exception) {
@@ -930,7 +930,7 @@ public interface JavaConstant {
                 @Override
                 public Object publicLookup() {
                     try {
-                        return publicLookup.invoke(null);
+                        return publicLookup.invoke(null, (Object[]) null);
                     } catch (IllegalAccessException exception) {
                         throw new IllegalStateException("Cannot access java.lang.invoke.MethodHandles#publicLookup", exception);
                     } catch (InvocationTargetException exception) {
@@ -941,7 +941,7 @@ public interface JavaConstant {
                 @Override
                 public Object getMethodType(Object methodHandleInfo) {
                     try {
-                        return getMethodType.invoke(methodHandleInfo);
+                        return getMethodType.invoke(methodHandleInfo, (Object[]) null);
                     } catch (IllegalAccessException exception) {
                         throw new IllegalStateException("Cannot access java.lang.invoke.MethodHandleInfo#getMethodType", exception);
                     } catch (InvocationTargetException exception) {
@@ -952,7 +952,7 @@ public interface JavaConstant {
                 @Override
                 public int getReferenceKind(Object methodHandleInfo) {
                     try {
-                        return (Integer) getReferenceKind.invoke(methodHandleInfo);
+                        return (Integer) getReferenceKind.invoke(methodHandleInfo, (Object[]) null);
                     } catch (IllegalAccessException exception) {
                         throw new IllegalStateException("Cannot access java.lang.invoke.MethodHandleInfo#getReferenceKind", exception);
                     } catch (InvocationTargetException exception) {
@@ -963,7 +963,7 @@ public interface JavaConstant {
                 @Override
                 public Class<?> getDeclaringClass(Object methodHandleInfo) {
                     try {
-                        return (Class<?>) getDeclaringClass.invoke(methodHandleInfo);
+                        return (Class<?>) getDeclaringClass.invoke(methodHandleInfo, (Object[]) null);
                     } catch (IllegalAccessException exception) {
                         throw new IllegalStateException("Cannot access java.lang.invoke.MethodHandleInfo#getDeclaringClass", exception);
                     } catch (InvocationTargetException exception) {
@@ -974,7 +974,7 @@ public interface JavaConstant {
                 @Override
                 public String getName(Object methodHandleInfo) {
                     try {
-                        return (String) getName.invoke(methodHandleInfo);
+                        return (String) getName.invoke(methodHandleInfo, (Object[]) null);
                     } catch (IllegalAccessException exception) {
                         throw new IllegalStateException("Cannot access java.lang.invoke.MethodHandleInfo#getName", exception);
                     } catch (InvocationTargetException exception) {
@@ -985,7 +985,7 @@ public interface JavaConstant {
                 @Override
                 public Class<?> returnType(Object methodType) {
                     try {
-                        return (Class<?>) returnType.invoke(methodType);
+                        return (Class<?>) returnType.invoke(methodType, (Object[]) null);
                     } catch (IllegalAccessException exception) {
                         throw new IllegalStateException("Cannot access java.lang.invoke.MethodType#returnType", exception);
                     } catch (InvocationTargetException exception) {
@@ -996,7 +996,7 @@ public interface JavaConstant {
                 @Override
                 public List<? extends Class<?>> parameterArray(Object methodType) {
                     try {
-                        return Arrays.asList((Class<?>[]) parameterArray.invoke(methodType));
+                        return Arrays.asList((Class<?>[]) parameterArray.invoke(methodType, (Object[]) null));
                     } catch (IllegalAccessException exception) {
                         throw new IllegalStateException("Cannot access java.lang.reflect.MethodType#parameterArray", exception);
                     } catch (InvocationTargetException exception) {
@@ -1007,7 +1007,7 @@ public interface JavaConstant {
                 @Override
                 public Class<?> lookupType(Object lookup) {
                     try {
-                        return (Class<?>) lookupClass.invoke(lookup);
+                        return (Class<?>) lookupClass.invoke(lookup, (Object[]) null);
                     } catch (IllegalAccessException exception) {
                         throw new IllegalStateException("Cannot access java.lang.reflect.MethodHandles.Lookup#lookupClass", exception);
                     } catch (InvocationTargetException exception) {

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/utility/JavaModule.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/utility/JavaModule.java
@@ -339,7 +339,7 @@ public class JavaModule implements NamedElement.WithOptionalName {
             @Override
             public JavaModule moduleOf(Class<?> type) {
                 try {
-                    return new JavaModule(getModule.invoke(type));
+                    return new JavaModule(getModule.invoke(type, (Object[]) null));
                 } catch (IllegalAccessException exception) {
                     throw new IllegalStateException("Cannot access " + getModule, exception);
                 } catch (InvocationTargetException exception) {
@@ -361,7 +361,7 @@ public class JavaModule implements NamedElement.WithOptionalName {
             @Override
             public ClassLoader getClassLoader(Object module) {
                 try {
-                    return (ClassLoader) getClassLoader.invoke(module);
+                    return (ClassLoader) getClassLoader.invoke(module, (Object[]) null);
                 } catch (IllegalAccessException exception) {
                     throw new IllegalStateException("Cannot access " + getClassLoader, exception);
                 } catch (InvocationTargetException exception) {
@@ -372,7 +372,7 @@ public class JavaModule implements NamedElement.WithOptionalName {
             @Override
             public boolean isNamed(Object module) {
                 try {
-                    return (Boolean) isNamed.invoke(module);
+                    return (Boolean) isNamed.invoke(module, (Object[]) null);
                 } catch (IllegalAccessException exception) {
                     throw new IllegalStateException("Cannot access " + isNamed, exception);
                 } catch (InvocationTargetException exception) {
@@ -383,7 +383,7 @@ public class JavaModule implements NamedElement.WithOptionalName {
             @Override
             public String getName(Object module) {
                 try {
-                    return (String) getName.invoke(module);
+                    return (String) getName.invoke(module, (Object[]) null);
                 } catch (IllegalAccessException exception) {
                     throw new IllegalStateException("Cannot access " + getName, exception);
                 } catch (InvocationTargetException exception) {


### PR DESCRIPTION
caused by the compiler that generates new Object[0] for Object... arguments