### PR TITLE
Do not leak classes via NexusAccessor

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/dynamic/NexusAccessor.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/dynamic/NexusAccessor.java
@@ -196,7 +196,7 @@ public class NexusAccessor {
             @SuppressFBWarnings(value = "REC_CATCH_EXCEPTION", justification = "Exception should not be rethrown but trigger a fallback")
             public Dispatcher run() {
                 if (Boolean.getBoolean(Nexus.PROPERTY)) {
-                    return new Unavailable(new IllegalStateException("Nexus injection was explicitly disabled"));
+                    return new Unavailable("Nexus injection was explicitly disabled");
                 } else {
                     try {
                         Class<?> nexusType = new ClassInjector.UsingReflection(ClassLoader.getSystemClassLoader(), ClassLoadingStrategy.NO_PROTECTION_DOMAIN)
@@ -210,7 +210,7 @@ public class NexusAccessor {
                             return new Dispatcher.Available(nexusType.getMethod("register", String.class, ClassLoader.class, ReferenceQueue.class, int.class, Object.class),
                                     nexusType.getMethod("clean", Reference.class));
                         } catch (Exception ignored) {
-                            return new Dispatcher.Unavailable(exception);
+                            return new Dispatcher.Unavailable(exception.toString());
                         }
                     }
                 }
@@ -288,17 +288,17 @@ public class NexusAccessor {
         class Unavailable implements Dispatcher {
 
             /**
-             * The exception that was raised during the dispatcher initialization.
+             * The reason for the dispatcher being unavailable.
              */
-            private final Exception exception;
+            private final String reason;
 
             /**
-             * Creates a new disabled dispatcher.
+             * Creates a new unavailable dispatcher.
              *
-             * @param exception The exception that was raised during the dispatcher initialization.
+             * @param reason The reason for the dispatcher being unavailable.
              */
-            protected Unavailable(Exception exception) {
-                this.exception = exception;
+            protected Unavailable(String reason) {
+                this.reason = reason;
             }
 
             @Override
@@ -308,7 +308,7 @@ public class NexusAccessor {
 
             @Override
             public void clean(Reference<? extends ClassLoader> reference) {
-                throw new IllegalStateException("Could not initialize Nexus accessor", exception);
+                throw new IllegalStateException("Could not initialize Nexus accessor: " + reason);
             }
 
             @Override
@@ -317,7 +317,7 @@ public class NexusAccessor {
                                  ReferenceQueue<? super ClassLoader> referenceQueue,
                                  int identification,
                                  LoadedTypeInitializer loadedTypeInitializer) {
-                throw new IllegalStateException("Could not initialize Nexus accessor", exception);
+                throw new IllegalStateException("Could not initialize Nexus accessor: " + reason);
             }
         }
     }

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/dynamic/NexusTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/dynamic/NexusTest.java
@@ -187,18 +187,18 @@ public class NexusTest {
 
     @Test
     public void testUnavailableState() throws Exception {
-        assertThat(new NexusAccessor.Dispatcher.Unavailable(new Exception()).isAlive(), is(false));
+        assertThat(new NexusAccessor.Dispatcher.Unavailable("unavailable").isAlive(), is(false));
     }
 
     @Test(expected = IllegalStateException.class)
     public void testUnavailableDispatcherRegisterThrowsException() throws Exception {
-        new NexusAccessor.Dispatcher.Unavailable(new Exception()).register(FOO, classLoader, Nexus.NO_QUEUE, BAR, loadedTypeInitializer);
+        new NexusAccessor.Dispatcher.Unavailable("unavailable").register(FOO, classLoader, Nexus.NO_QUEUE, BAR, loadedTypeInitializer);
     }
 
     @Test(expected = IllegalStateException.class)
     @SuppressWarnings("unchecked")
     public void testUnavailableDispatcherCleanThrowsException() throws Exception {
-        new NexusAccessor.Dispatcher.Unavailable(new Exception()).clean(mock(Reference.class));
+        new NexusAccessor.Dispatcher.Unavailable("unavailable").clean(mock(Reference.class));
     }
 
     @Test


### PR DESCRIPTION
before this change there was an exception attached to the unavailable NexusAccessor.

This exception is either a problem, or it was constructed when injection was disabled.

Unfortunately, this stack trace captures all the classes that were on the stack when the NexusAccesor was first time used.
Since this is just for information only, this PR changes it to a String reason, instead of the stack, thus removing the leakage of classes.