### PR TITLE
Upgrade to ASM 6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <code.level>1.6</code.level>
         <pitest.target>net.bytebuddy</pitest.target>
-        <asm.javadoc>http://asm.ow2.org/asm60/javadoc/user/</asm.javadoc>
-        <version.asm>6.1.1</version.asm>
+        <asm.javadoc>http://asm.ow2.io/javadoc</asm.javadoc>
+        <version.asm>6.2</version.asm>
         <version.junit>4.12</version.junit>
         <version.mockito>2.18.0</version.mockito>
         <version.plugin.clean>3.0.0</version.plugin.clean>


### PR DESCRIPTION
Also fixes the ASM Javadoc link. Which still points to 6.1.1. Same goes for the _Versions_ overview at http://asm.ow2.io/versions.html

_Only_ 7 tests of 7817 fail after the upgrade. Underlying JDK version doesn't seem to matter, same 7 failures on JDK 6, 7 and 8 (AppVeyor) and JDK 9, 10 and 11 (Travis):
```
[ERROR] Errors: 
[ERROR]   TypeDescriptionArrayProjectionTest>AbstractTypeDescriptionGenericTest.testGenericTypeInconsistency:1235 » ClassFormat
[ERROR]   TypeDescriptionForLoadedTypeTest>AbstractTypeDescriptionGenericTest.testGenericTypeInconsistency:1235 » ClassFormat
[ERROR]   TypeDescriptionGenericBuilderTest>AbstractTypeDescriptionGenericTest.testGenericTypeInconsistency:1235 » ClassFormat
[ERROR]   TypePoolDefaultTypeDescriptionSuperClassLoadingTest>AbstractTypeDescriptionGenericTest.testGenericTypeInconsistency:1235 » ClassFormat
[ERROR]   TypePoolDefaultTypeDescriptionTest>AbstractTypeDescriptionGenericTest.testGenericTypeInconsistency:1235 » ClassFormat
[ERROR]   TypePoolDefaultWithLazyResolutionTypeDescriptionTest>AbstractTypeDescriptionGenericTest.testGenericTypeInconsistency:1235 » ClassFormat
[ERROR]   TypePoolLazyFacadeTypeDescriptionTest>AbstractTypeDescriptionGenericTest.testGenericTypeInconsistency:1235 » ClassFormat
[INFO] 
[ERROR] Tests run: 7817, Failures: 0, Errors: 7, Skipped: 24
```

Was some `GenericTypeInconsistency` fixed?