### PR TITLE
Favor included CL over CL of transformed class

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/agent/builder/AgentBuilder.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/agent/builder/AgentBuilder.java
@@ -2135,7 +2135,7 @@ public interface AgentBuilder {
                                                     TypeDescription typeDescription,
                                                     ClassLoader classLoader,
                                                     JavaModule module) {
-                ClassFileLocator classFileLocator = new ClassFileLocator.Compound(locationStrategy.classFileLocator(classLoader, module), this.classFileLocator);
+                ClassFileLocator classFileLocator = new ClassFileLocator.Compound(this.classFileLocator, locationStrategy.classFileLocator(classLoader, module));
                 TypePool typePool = poolStrategy.typePool(classFileLocator, classLoader);
                 AsmVisitorWrapper.ForDeclaredMethods asmVisitorWrapper = new AsmVisitorWrapper.ForDeclaredMethods();
                 for (Entry entry : entries) {


### PR DESCRIPTION
Ok, this is a strange one and admittedly a workaround for a very specific case. Nonetheless, I think it also makes sense in a general setting to favor the loading of advices by the class loader added via `net.bytebuddy.agent.builder.AgentBuilder.Transformer.ForAdvice#include(java.lang.ClassLoader...)` as opposed to the classloader of the class which is currently being transformed.

My actual problem:

Due to a strange behavior of both `java.lang.instrument.Instrumentation#appendToBootstrapClassLoaderSearch` and a Glassfish classloader, classes which have been tried to load as a resource (`ClassLoader#getResource`), can afterwards not be loaded anymore via `ClassLoader#loadClass`. Example:

```java
cl.loadClass("org.example.TestClass"); // success
cl.getResource("org/example/TestClass.class"); // returns null
cl.loadClass("org.example.TestClass"); // ClassNotFoundException
```

The problem is that when adding a jar file to the bootstrap classloader, `Instrumentation#appendToBootstrapClassLoaderSearch` it's contents can't be loaded by calling the bootstrap classloader's `getResource` method. See https://stackoverflow.com/questions/51347432/why-cant-i-load-resources-which-are-appended-to-the-bootstrap-class-loader-sear.

The boot delegation (`org.osgi.framework.bootdelegation`) in Glassfish, or rather Apache Felix only works for classes loaded by the bootstrap classloader and not the system classloader. This is one of the reasons I add my agent jar to the bootstrap classloader, which makes it available to both the system classloader and the bootstrap classloader.

Glassfish's `APIClassLoaderServiceImpl` [blacklists all classes it could not successfully load](https://github.com/javaee/glassfish/blob/master/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/APIClassLoaderServiceImpl.java#L322). That means that an unsuccessful attempt to load a class file as a resource is remembered and [short-circuits](https://github.com/javaee/glassfish/blob/965a34248543d0f7945b3838b131880836e8e5aa/nucleus/core/kernel/src/main/java/com/sun/enterprise/v3/server/APIClassLoaderServiceImpl.java#L230) the loading of the same class in the future.

Same example as above, with more explainations:
```java
// success, because the class is added to the bootstrap classloader
// and enabling boot delegation for the org.example package makes sure
// the bootstrap classloader is actually asked to load the class
cl.loadClass("org.example.TestClass"); // success 
// can't load the resource, as Felix does not consult the system class loader
// as part of the boot delegation
// and the bootstrap class loader can't load resources added via
// `Instrumentation#appendToBootstrapClassLoaderSearch`
// -> adds org/example/TestClass.class to blacklist
cl.getResource("org/example/TestClass.class"); // returns null
// because org/example/TestClass.class has been added to the blacklist,
// the class loading is short-circuited
cl.loadClass("org.example.TestClass"); // ClassNotFoundException
```

So the actual source of this problem is that the `APIClassLoaderServiceImpl` classloader is assuming that a failure to get a class file resource automatically means that loading the corresponding class is not possible as well. This assumption is not true, as `java.lang.instrument.Instrumentation#appendToBootstrapClassLoaderSearch` makes classes only loadable by the bootstrap classloader (`ClassLoader#loadClass`) but does not allow the bootstrap classloader to get resources (`ClassLoader#getResource`) from the added jar file.

I know that this is not a Byte Buddy issue, but IMHO Byte Buddy should allow to work-around that situation, either by giving precedence to the classloader added by `AgentBuilder.Transformer.ForAdvice#include(java.lang.ClassLoader...)` (as this PR does) or by giving full conrol over which classloaders are used to load the advices.