### PR TITLE
Do not try to set timeout for VirtualMachine#attach when its 0

### DIFF
--- a/byte-buddy-agent/src/main/java/net/bytebuddy/agent/VirtualMachine.java
+++ b/byte-buddy-agent/src/main/java/net/bytebuddy/agent/VirtualMachine.java
@@ -315,7 +315,9 @@ public interface VirtualMachine {
                         }
                     }
                 }
-                ((AFUNIXSocket) socket).setSoTimeout((int) timeUnit.toMillis(timeout));
+                if (timeout != 0) {
+                  ((AFUNIXSocket) socket).setSoTimeout((int) timeUnit.toMillis(timeout));
+                }
                 ((AFUNIXSocket) socket).connect(new AFUNIXSocketAddress(socketFile));
             }
 


### PR DESCRIPTION
In case the socket does not support setting a timeout, one can use 0, which means no timeout and is the default on an AFUNIXSocket