### PR TITLE
Avoid leaking matchers via resubmission

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/agent/builder/AgentBuilder.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/agent/builder/AgentBuilder.java
@@ -5803,7 +5803,7 @@ public interface AgentBuilder {
                 /**
                  * A job that resubmits any matched type that previously failed during transformation.
                  */
-                protected static class ResubmissionInstallationListener extends AgentBuilder.InstallationListener.Adapter implements Runnable {
+                protected static class ResubmissionInstallationListener extends AgentBuilder.InstallationListener.Adapter {
 
                     /**
                      * The resubmission scheduler to use.
@@ -5860,6 +5860,8 @@ public interface AgentBuilder {
                      */
                     private volatile ResubmissionScheduler.Cancelable cancelable;
 
+                    private volatile LeakPrevention job;
+
                     /**
                      * Creates a new resubmission job.
                      *
@@ -5896,10 +5898,10 @@ public interface AgentBuilder {
                         this.types = types;
                     }
 
-
                     @Override
                     public void onInstall(Instrumentation instrumentation, ResettableClassFileTransformer classFileTransformer) {
-                        cancelable = resubmissionScheduler.schedule(this);
+                        job = new LeakPrevention(this);
+                        cancelable = resubmissionScheduler.schedule(job);
                     }
 
                     @Override
@@ -5908,13 +5910,23 @@ public interface AgentBuilder {
                         if (cancelable != null) {
                             cancelable.cancel();
                         }
+                        job.resubmissionInstallationListener = null;
                     }
 
+                    private static final class LeakPrevention implements Runnable {
+                      
+                      private volatile ResubmissionInstallationListener resubmissionInstallationListener;
+
+                      public LeakPrevention(ResubmissionInstallationListener resubmissionInstallationListener) {
+                        this.resubmissionInstallationListener = resubmissionInstallationListener;
+                      }
+                    
                     @Override
                     public void run() {
-                        boolean release = circularityLock.acquire();
+                      ResubmissionInstallationListener ril = this.resubmissionInstallationListener; 
+                        boolean release = ril.circularityLock.acquire();
                         try {
-                            Iterator<Map.Entry<StorageKey, Set<String>>> entries = types.entrySet().iterator();
+                            Iterator<Map.Entry<StorageKey, Set<String>>> entries = ril.types.entrySet().iterator();
                             List<Class<?>> types = new ArrayList<Class<?>>();
                             while (!Thread.interrupted() && entries.hasNext()) {
                                 Map.Entry<StorageKey, Set<String>> entry = entries.next();
@@ -5925,7 +5937,7 @@ public interface AgentBuilder {
                                         try {
                                             Class<?> type = Class.forName(iterator.next(), false, classLoader);
                                             try {
-                                                if (instrumentation.isModifiableClass(type) && matcher.matches(TypeDescription.ForLoadedType.of(type),
+                                                if (ril.instrumentation.isModifiableClass(type) && ril.matcher.matches(TypeDescription.ForLoadedType.of(type),
                                                         type.getClassLoader(),
                                                         JavaModule.ofType(type),
                                                         type,
@@ -5934,13 +5946,13 @@ public interface AgentBuilder {
                                                 }
                                             } catch (Throwable throwable) {
                                                 try {
-                                                    listener.onError(TypeDescription.ForLoadedType.getName(type),
+                                                    ril.listener.onError(TypeDescription.ForLoadedType.getName(type),
                                                             type.getClassLoader(),
                                                             JavaModule.ofType(type),
                                                             AgentBuilder.Listener.LOADED,
                                                             throwable);
                                                 } finally {
-                                                    listener.onComplete(TypeDescription.ForLoadedType.getName(type),
+                                                    ril.listener.onComplete(TypeDescription.ForLoadedType.getName(type),
                                                             type.getClassLoader(),
                                                             JavaModule.ofType(type),
                                                             AgentBuilder.Listener.LOADED);
@@ -5957,21 +5969,22 @@ public interface AgentBuilder {
                                 }
                             }
                             if (!types.isEmpty()) {
-                                RedefinitionStrategy.Collector collector = redefinitionStrategy.make();
+                                RedefinitionStrategy.Collector collector = ril.redefinitionStrategy.make();
                                 collector.include(types);
-                                collector.apply(instrumentation,
-                                        circularityLock,
-                                        locationStrategy,
-                                        listener,
-                                        redefinitionBatchAllocator,
-                                        redefinitionBatchListener,
+                                collector.apply(ril.instrumentation,
+                                        ril.circularityLock,
+                                        ril.locationStrategy,
+                                        ril.listener,
+                                        ril.redefinitionBatchAllocator,
+                                        ril.redefinitionBatchListener,
                                         BatchAllocator.FIRST_BATCH);
                             }
                         } finally {
                             if (release) {
-                                circularityLock.release();
+                                ril.circularityLock.release();
                             }
                         }
+                    }
                     }
                 }
 


### PR DESCRIPTION
<img width="1013" alt="screen shot 2018-08-27 at 10 09 40" src="https://user-images.githubusercontent.com/176132/44649306-c904b780-a9e3-11e8-95e0-da55c54f8a2f.png">
This screenshot from Eclipse MAT shows that its possible to leak Matcher instances (and with it a whole tree of Instrumentation things) when the Resubmission Executor is reused after an instrumentation has `reset`.

The reason is that its possible that the `ResubmissionInstallationListener` (implements Runnable) still sits in the Executor queue.

To avoid that, we should also release all references to heavy classes (like Matchers) after cancel is invoked.

Please rename/reformat to your liking.