### PR TITLE
Cosmetic improvement of the Matchers look during debugging: anyOf and noneOf

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/matcher/ElementMatchers.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/matcher/ElementMatchers.java
@@ -346,11 +346,19 @@ public final class ElementMatchers {
      * @return A matcher that checks for the equality with any of the given objects.
      */
     public static <T> ElementMatcher.Junction<T> anyOf(Iterable<?> values) {
-        ElementMatcher.Junction<T> matcher = none();
+        ElementMatcher.Junction<T> matcher = null;
         for (Object value : values) {
-            matcher = matcher.or(is(value));
+            if (matcher == null) {
+                matcher = is(value);
+            } else {
+                matcher = matcher.or(is(value));
+            }
         }
-        return matcher;
+        if (matcher == null) {
+            return none();
+        } else {
+            return matcher;
+        }
     }
 
     /**

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/matcher/ElementMatchers.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/matcher/ElementMatchers.java
@@ -442,11 +442,19 @@ public final class ElementMatchers {
      * @return A matcher that checks for the equality with none of the given objects.
      */
     public static <T> ElementMatcher.Junction<T> noneOf(Iterable<?> values) {
-        ElementMatcher.Junction<T> matcher = any();
+        ElementMatcher.Junction<T> matcher = null;
         for (Object value : values) {
-            matcher = matcher.and(not(is(value)));
+            if (matcher == null) {
+                matcher = not(is(value));
+            } else {
+                matcher = matcher.and(not(is(value)));
+            }
         }
-        return matcher;
+        if (matcher == null) {
+            return any();
+        } else {
+            return matcher;
+        }
     }
 
     /**

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/matcher/ElementMatchersTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/matcher/ElementMatchersTest.java
@@ -389,10 +389,11 @@ public class ElementMatchersTest {
 
     @Test
     public void testNoneOf() throws Exception {
-        Object value = new Object(), otherValue = new Object();
+        final Object value = "object1", otherValue = "object2";
         assertThat(ElementMatchers.noneOf(value, otherValue).matches(value), is(false));
         assertThat(ElementMatchers.noneOf(value, otherValue).matches(otherValue), is(false));
         assertThat(ElementMatchers.noneOf(value, otherValue).matches(new Object()), is(true));
+        assertThat(ElementMatchers.noneOf(value, otherValue).toString(), is("(not(is(object1)) and not(is(object2)))"));
     }
 
     @Test

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/matcher/ElementMatchersTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/matcher/ElementMatchersTest.java
@@ -380,10 +380,11 @@ public class ElementMatchersTest {
 
     @Test
     public void testAnyOf() throws Exception {
-        Object value = new Object(), otherValue = new Object();
+        final Object value = "object1", otherValue = "object2";
         assertThat(ElementMatchers.anyOf(value, otherValue).matches(value), is(true));
         assertThat(ElementMatchers.anyOf(value, otherValue).matches(otherValue), is(true));
         assertThat(ElementMatchers.anyOf(value, otherValue).matches(new Object()), is(false));
+        assertThat(ElementMatchers.anyOf(value, otherValue).toString(), is("(is(object1) or is(object2))"));
     }
 
     @Test


### PR DESCRIPTION

When debugging non trivial Matcher trees being represented as string, this helps being a little less verbose.

Should have a positive impact on performance too, although likely too small to be measureable.