### PR TITLE
 Fix IllegalArgumentException when dynamically subclassing classes from the default package in JDK9+

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/dynamic/loading/ClassInjector.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/dynamic/loading/ClassInjector.java
@@ -1409,7 +1409,9 @@ public interface ClassInjector {
             Map<String, Class<?>> result = new HashMap<String, Class<?>>();
             for (Map.Entry<? extends String, byte[]> entry : types.entrySet()) {
                 int index = entry.getKey().lastIndexOf('.');
-                if (index == -1 || !entry.getKey().substring(0, index).equals(TypeDescription.ForLoadedType.of(lookupType()).getPackage().getName())) {
+                String expectedPackage = TypeDescription.ForLoadedType.of(lookupType()).getPackage().getName();
+                String actualPackage = index == -1 ? "" : entry.getKey().substring(0, index);
+                if (!expectedPackage.equals(actualPackage)) {
                     throw new IllegalArgumentException(entry.getKey() + " must be defined in the same package as " + lookup);
                 }
                 result.put(entry.getKey(), DISPATCHER.defineClass(lookup, entry.getValue()));

--- a/byte-buddy-dep/src/test/java/NoPackageType.java
+++ b/byte-buddy-dep/src/test/java/NoPackageType.java
@@ -1,0 +1,2 @@
+public class NoPackageType {
+}

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/dynamic/scaffold/subclass/NoPackageSubclassDynamicTypeBuilderTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/dynamic/scaffold/subclass/NoPackageSubclassDynamicTypeBuilderTest.java
@@ -1,0 +1,60 @@
+package net.bytebuddy.dynamic.scaffold.subclass;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.MethodRule;
+
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+import net.bytebuddy.test.packaging.NoPackageTypeHolder;
+import net.bytebuddy.test.utility.JavaVersionRule;
+import net.bytebuddy.utility.JavaType;
+import org.hamcrest.CoreMatchers;
+
+public class NoPackageSubclassDynamicTypeBuilderTest {
+
+    @Rule
+    public MethodRule javaVersionRule = new JavaVersionRule();
+
+    /*
+     * Executes MethodHandles.privateLookupIn(clazz, MethodHandles.lookup()) using reflection
+     * to be able to compile with Java 8 and below.
+     */
+    private static Object privateLookupIn(Class<?> clazz)
+            throws IllegalAccessException, InvocationTargetException, NoSuchMethodException, ClassNotFoundException {
+        return JavaType.METHOD_HANDLES.load()
+                .getMethod( "privateLookupIn", Class.class, JavaType.METHOD_HANDLES_LOOKUP.load() )
+                .invoke( null, clazz, JavaType.METHOD_HANDLES.load().getMethod( "lookup" ).invoke( null  ) );
+    }
+
+    @Test
+    @JavaVersionRule.Enforce(9)
+    public void testSubclassUsingLookup() throws Exception {
+        Class<?> type = new ByteBuddy()
+                .subclass(NoPackageTypeHolder.TYPE)
+                .make()
+                .load(
+                        NoPackageTypeHolder.TYPE.getClassLoader(),
+                        ClassLoadingStrategy.UsingLookup.of(privateLookupIn(NoPackageTypeHolder.TYPE))
+                )
+                .getLoaded();
+        assertThat(type.getDeclaredMethods().length, is(0));
+        assertThat(type.getDeclaredConstructors().length, is(1));
+        assertThat(type.getDeclaredConstructor(), notNullValue( Constructor.class));
+        assertThat(NoPackageTypeHolder.TYPE.isAssignableFrom(type), is(true));
+        assertThat(type, not(CoreMatchers.<Class<?>>is(NoPackageTypeHolder.TYPE)));
+        assertThat(type.getDeclaredConstructor().newInstance(), CoreMatchers.instanceOf(NoPackageTypeHolder.TYPE));
+        assertTrue(NoPackageTypeHolder.TYPE.isInstance(type.getDeclaredConstructor().newInstance()));
+        assertThat(type.isInterface(), is(false));
+        assertThat(type.isAnnotation(), is(false));
+    }
+}

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/test/packaging/NoPackageTypeHolder.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/test/packaging/NoPackageTypeHolder.java
@@ -1,0 +1,29 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package net.bytebuddy.test.packaging;
+
+public class NoPackageTypeHolder {
+
+	public static final Class<?> TYPE;
+
+	static {
+		try {
+			/*
+			 * We have to use reflection to access a type from the default package,
+			 * because normally those types can only be used from the default package,
+			 * and we don't really want to put tests in the default package.
+			 */
+			TYPE = Class.forName("NoPackageType");
+		}
+		catch (ClassNotFoundException e) {
+			throw new IllegalStateException(
+					"Unexpected error while trying to access a class from the default package", e
+			);
+		}
+	}
+
+}


### PR DESCRIPTION
Fixes #568

Not sure the tests are in the right package, and maybe there's a way to execute more tests on classes in the default package by extending some abstract base, but I don't know enough about the testing infrastructure to do better :)