### PR TITLE
Mark OpenJ9 Travis build as "allow_failures"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ matrix:
     - env: JDK="OpenJ9 11" TARGET='-Pjava11' EXPERIMENTAL='true'
       before_script:
         - . ci/install-jdk.sh -W ~/custom-java --url "https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=openj9&os=linux&arch=x64&release=latest&type=jdk&heap_size=normal"
+  allow_failures:
+    # OpenJ9 11 is currently failing
+    - env: JDK="OpenJ9 11" TARGET='-Pjava11' EXPERIMENTAL='true'
 
 script:
   - ./mvnw install ${TARGET} -DskipTests=true -Dmaven.javadoc.skip=true -Dnet.bytebuddy.experimental=${EXPERIMENTAL} -Dnet.bytebuddy.test.ci=true -pl '!byte-buddy-gradle-plugin'


### PR DESCRIPTION
Just in a case you want to have green Travis builds until fixed/enhanced :).

![image](https://user-images.githubusercontent.com/148013/57708258-51f27a80-7669-11e9-974b-258ce2b09001.png)
