### PR TITLE
Delete temporary jar files on exit

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/dynamic/loading/ClassInjector.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/dynamic/loading/ClassInjector.java
@@ -2126,6 +2126,7 @@ ClassInjector {
                 if (!jarFile.createNewFile()) {
                     throw new IllegalStateException("Cannot create file " + jarFile);
                 }
+                jarFile.deleteOnExit();
                 JarOutputStream jarOutputStream = new JarOutputStream(new FileOutputStream(jarFile));
                 try {
                     for (Map.Entry<? extends String, byte[]> entry : types.entrySet()) {


### PR DESCRIPTION
This cleans up the temporary jars that bytebuddy creates.

Minor change, but we've had clients complain.