### PR TITLE
Check JNA version when resolving emulated VM

### DIFF
--- a/byte-buddy-agent/src/main/java/net/bytebuddy/agent/VirtualMachine.java
+++ b/byte-buddy-agent/src/main/java/net/bytebuddy/agent/VirtualMachine.java
@@ -134,9 +134,10 @@ public interface VirtualMachine {
          */
         public Class<? extends VirtualMachine> run() {
             try {
-                Class.forName("com.sun.jna.Platform");
-            } catch (ClassNotFoundException exception) {
-                throw new IllegalStateException("Optional JNA dependency is not available", exception);
+                Class<?> nativeClass = Class.forName("com.sun.jna.Native");
+                nativeClass.getMethod("load", String.class, Class.class);
+            } catch (Exception exception) {
+                throw new IllegalStateException("Optional JNA dependency is not available or is not at least version 5", exception);
             }
             return System.getProperty("java.vm.vendor").toUpperCase(Locale.US).contains("J9")
                     ? ForOpenJ9.class

--- a/byte-buddy-agent/src/main/java/net/bytebuddy/agent/VirtualMachine.java
+++ b/byte-buddy-agent/src/main/java/net/bytebuddy/agent/VirtualMachine.java
@@ -134,10 +134,11 @@ public interface VirtualMachine {
          */
         public Class<? extends VirtualMachine> run() {
             try {
-                Class<?> nativeClass = Class.forName("com.sun.jna.Native");
-                nativeClass.getMethod("load", String.class, Class.class);
-            } catch (Exception exception) {
-                throw new IllegalStateException("Optional JNA dependency is not available or is not at least version 5", exception);
+                Class.forName("com.sun.jna.Native").getMethod("load", String.class, Class.class);
+            } catch (ClassNotFoundException exception) {
+                throw new IllegalStateException("Optional JNA dependency is not available", exception);
+            } catch (NoSuchMethodException exception) {
+                throw new IllegalStateException("JNA dependency is not at least version 5", exception);
             }
             return System.getProperty("java.vm.vendor").toUpperCase(Locale.US).contains("J9")
                     ? ForOpenJ9.class


### PR DESCRIPTION
The emulated attach requires JNA 5 but Byte Buddy will happily resolve the emulated `VirtualMachine` and fail with a `NoSuchMethodError` if JNA 4 is present. This can happen quite unexpectedly when inheriting from Spring Boot's parent pom, as it overrides the JNA version. See also https://github.com/elastic/apm-agent-java/pull/775