### PR TITLE
Fixed ASM guide URL

### DIFF
--- a/partial/tutorial.partial.html
+++ b/partial/tutorial.partial.html
@@ -2211,7 +2211,7 @@ new ByteBuddy()
 
 <p>
     The ASM library comes with
-    <a href="http://download.forge.objectweb.org/asm/asm4-guide.pdf">an excellent documentation</a> of Java byte
+    <a href="https://asm.ow2.io/asm4-guide.pdf">an excellent documentation</a> of Java byte
     code and on the use of the library. Therefore, we want to refer you to this documentation in case that you want
     to learn in detail about Java byte code and ASM's API. Instead, we are only going to provide a brief introduction
     to the JVM's execution model and Byte Buddy's adaption of ASM's API.


### PR DESCRIPTION
Fixed ASM guide URL, the previous one hosted on http://forge.objectweb.org is no longer available, see: https://www.ow2.org/view/IT_Infrastructure/GForge_discontinued