### PR TITLE
[#802] quote java process path when it contains a whitespace

### DIFF
--- a/byte-buddy-agent/src/main/java/net/bytebuddy/agent/ByteBuddyAgent.java
+++ b/byte-buddy-agent/src/main/java/net/bytebuddy/agent/ByteBuddyAgent.java
@@ -661,9 +661,9 @@ public class ByteBuddyAgent {
             for (File jar : externalAttachment.getClassPath()) {
                 classPath.append(File.pathSeparatorChar).append(quote(jar.getCanonicalPath()));
             }
-            if (new ProcessBuilder(quote(System.getProperty(JAVA_HOME))
+            if (new ProcessBuilder(quote(System.getProperty(JAVA_HOME)
                     + File.separatorChar + "bin"
-                    + File.separatorChar + (System.getProperty(OS_NAME, "").toLowerCase(Locale.US).contains("windows") ? "java.exe" : "java"),
+                    + File.separatorChar + (System.getProperty(OS_NAME, "").toLowerCase(Locale.US).contains("windows") ? "java.exe" : "java")),
                     CLASS_PATH_ARGUMENT,
                     classPath.toString(),
                     Attacher.class.getName(),

--- a/byte-buddy-agent/src/main/java/net/bytebuddy/agent/ByteBuddyAgent.java
+++ b/byte-buddy-agent/src/main/java/net/bytebuddy/agent/ByteBuddyAgent.java
@@ -661,7 +661,7 @@ public class ByteBuddyAgent {
             for (File jar : externalAttachment.getClassPath()) {
                 classPath.append(File.pathSeparatorChar).append(quote(jar.getCanonicalPath()));
             }
-            if (new ProcessBuilder(System.getProperty(JAVA_HOME)
+            if (new ProcessBuilder(quote(System.getProperty(JAVA_HOME))
                     + File.separatorChar + "bin"
                     + File.separatorChar + (System.getProperty(OS_NAME, "").toLowerCase(Locale.US).contains("windows") ? "java.exe" : "java"),
                     CLASS_PATH_ARGUMENT,


### PR DESCRIPTION
**Context: #802**

On some operating systems such as MacOS, whitespaces in the `$JAVA_HOME` path cause problems while building a new process. This pull request aims to fix this.

kudos to @dengarcia for pointing out the solution! 🥇