### PR TITLE
implement namedOneOf matcher for NamedElements

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/matcher/ElementMatchers.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/matcher/ElementMatchers.java
@@ -657,6 +657,17 @@ public final class ElementMatchers {
     }
 
     /**
+     * Matches a {@link NamedElement} for its membership of a set.
+     *
+     * @param names The set of expected names.
+     * @param <T>  The type of the matched object.
+     * @return An element matcher which matches if the element's name is found in the set.
+     */
+    public static <T extends NamedElement> ElementMatcher.Junction<T> namedOneOf(String... names) {
+        return new NameMatcher<T>(new StringSetMatcher(names));
+    }
+
+    /**
      * Matches a {@link NamedElement} for its name. The name's
      * capitalization is ignored.
      *

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/matcher/StringSetMatcher.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/matcher/StringSetMatcher.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014 - 2020 Rafael Winterhalter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.bytebuddy.matcher;
+
+import net.bytebuddy.build.HashCodeAndEqualsPlugin;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * An element matcher which checks if a string is in a set of strings.
+ */
+@HashCodeAndEqualsPlugin.Enhance
+public class StringSetMatcher extends ElementMatcher.Junction.AbstractBase<String> {
+
+  private final Set<String> set;
+
+  public StringSetMatcher(String... values) {
+    this.set = new HashSet<String>(values.length * 4 / 3);
+    // do it manually to avoid allocations or rehashing
+    for (String value : values) {
+      set.add(value);
+    }
+  }
+
+  @Override
+  public boolean matches(String target) {
+    return set.contains(target);
+  }
+
+  @Override
+  public String toString() {
+    return "in(" + set + ")";
+  }
+}

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/matcher/ElementMatchersTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/matcher/ElementMatchersTest.java
@@ -446,6 +446,16 @@ public class ElementMatchersTest {
     }
 
     @Test
+    public void testNamedOneOf() throws Exception {
+        ByteCodeElement byteCodeElement = mock(ByteCodeElement.class);
+        when(byteCodeElement.getActualName()).thenReturn(FOO);
+        assertThat(namedOneOf(FOO, BAR).matches(byteCodeElement), is(true));
+        assertThat(namedOneOf(FOO.toUpperCase(), BAR).matches(byteCodeElement), is(false));
+        assertThat(namedOneOf(FOO.toUpperCase()).matches(byteCodeElement), is(false));
+        assertThat(namedOneOf(BAR).matches(byteCodeElement), is(false));
+    }
+
+    @Test
     public void testNamedIgnoreCase() throws Exception {
         ByteCodeElement byteCodeElement = mock(ByteCodeElement.class);
         when(byteCodeElement.getActualName()).thenReturn(FOO);

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/matcher/StringSetMatcherTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/matcher/StringSetMatcherTest.java
@@ -1,0 +1,51 @@
+package net.bytebuddy.matcher;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(Parameterized.class)
+public class StringSetMatcherTest extends AbstractElementMatcherTest<StringSetMatcher> {
+
+  private final String[] names;
+
+  private final String matching, nonMatching;
+
+  public StringSetMatcherTest(String[] names, String matching, String nonMatching) {
+    super(StringSetMatcher.class, Arrays.toString(names));
+    this.names = names;
+    this.matching = matching;
+    this.nonMatching = nonMatching;
+  }
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][]{
+            {new String[] {"fo", "fo", "fo"}, "fo", "fooo"},
+            {new String[] {"fo"}, "fo", "fooo"},
+            {new String[] {"f", "fo", "foo"}, "fo", "fooo"}
+    });
+  }
+
+  @Test
+  public void testMatch() throws Exception {
+    assertThat(new StringSetMatcher(names).matches(matching), is(true));
+  }
+
+  @Test
+  public void testNoMatch() throws Exception {
+    assertThat(new StringSetMatcher(names).matches(nonMatching), is(false));
+  }
+
+  @Test
+  public void testStringRepresentation() {
+    assertThat(new StringSetMatcher(names).toString(), startsWith("in("));
+  }
+}


### PR DESCRIPTION
This matcher can be used to replace long chains of `.or(named(...))` rules.