### PR TITLE
avoid recursive getInterfaces for HasSuperTypeMatcher

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/matcher/HasSuperTypeMatcher.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/matcher/HasSuperTypeMatcher.java
@@ -18,6 +18,7 @@ package net.bytebuddy.matcher;
 import net.bytebuddy.build.HashCodeAndEqualsPlugin;
 import net.bytebuddy.description.type.TypeDefinition;
 import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.pool.ResolutionIllegalStateException;
 
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -63,7 +64,11 @@ public class HasSuperTypeMatcher<T extends TypeDescription> extends ElementMatch
                     if (matcher.matches(interfaceType.asGenericType())) {
                         return true;
                     } else {
-                        interfaceTypes.addAll(interfaceType.getInterfaces());
+                        try {
+                            interfaceTypes.addAll(interfaceType.getInterfaces());
+                        } catch (ResolutionIllegalStateException ex) {
+                            continue;
+                        }
                     }
                 }
             }

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/pool/ResolutionIllegalStateException.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/pool/ResolutionIllegalStateException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014 - 2020 Rafael Winterhalter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.bytebuddy.pool;
+
+/**
+ * IllegalStateException for Illegal Resolution.
+ */
+public class ResolutionIllegalStateException extends IllegalStateException {
+
+  /** */
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * @param msg - msg
+   */
+  protected ResolutionIllegalStateException(String msg) {
+    super(msg);
+  }
+}

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/pool/TypePool.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/pool/TypePool.java
@@ -154,7 +154,7 @@ public interface TypePool {
              * {@inheritDoc}
              */
             public TypeDescription resolve() {
-                throw new IllegalStateException("Cannot resolve type description for " + name);
+                throw new ResolutionIllegalStateException("Cannot resolve type description for " + name);
             }
         }
     }


### PR DESCRIPTION
```
WARN 2020-07-30 09:17:02:683 main ProtectiveShieldMatcher : Byte-buddy occurs exception when match type.
java.lang.IllegalStateException: Cannot resolve type description for com.ibm.wsspi.bootstrap.osgi.WsBundleActivator
		at org.apache.skywalking.apm.dependencies.net.bytebuddy.pool.TypePool$Resolution$Illegal.resolve(TypePool.java:159)
		at org.apache.skywalking.apm.dependencies.net.bytebuddy.pool.TypePool$Default$WithLazyResolution$LazyTypeDescription.delegate(TypePool.java:914)
		at org.apache.skywalking.apm.dependencies.net.bytebuddy.description.type.TypeDescription$AbstractBase$OfSimpleType$WithDelegation.getSuperClass(TypeDescription.java:8031)
		at org.apache.skywalking.apm.dependencies.net.bytebuddy.description.type.TypeDescription$Generic$OfNonGenericType.getSuperClass(TypeDescription.java:3619)
		at org.apache.skywalking.apm.dependencies.net.bytebuddy.description.type.TypeDescription$Generic$LazyProjection$WithEagerNavigation.getSuperClass(TypeDescription.java:6368)
		at org.apache.skywalking.apm.dependencies.net.bytebuddy.description.type.TypeDefinition$SuperClassIterator.next(TypeDefinition.java:314)
		at org.apache.skywalking.apm.dependencies.net.bytebuddy.description.type.TypeDefinition$SuperClassIterator.next(TypeDefinition.java:281)
		at org.apache.skywalking.apm.dependencies.net.bytebuddy.matcher.HasSuperTypeMatcher.matches(HasSuperTypeMatcher.java:53)
		at org.apache.skywalking.apm.dependencies.net.bytebuddy.matcher.HasSuperTypeMatcher.matches(HasSuperTypeMatcher.java:31)
		at org.apache.skywalking.apm.dependencies.net.bytebuddy.matcher.ElementMatcher$Junction$Conjunction.matches(ElementMatcher.java:122)
		at org.apache.skywalking.apm.dependencies.net.bytebuddy.matcher.ElementMatcher$Junction$Disjunction.matches(ElementMatcher.java:160)
		at org.apache.skywalking.apm.dependencies.net.bytebuddy.matcher.ElementMatcher$Junction$Disjunction.matches(ElementMatcher.java:160)
```