### PR TITLE
move evaluation of `byteBuddyExtension.implies` into TransformationAc…

### DIFF
--- a/byte-buddy-gradle-plugin/src/main/java/net/bytebuddy/build/gradle/PostCompilationAction.java
+++ b/byte-buddy-gradle-plugin/src/main/java/net/bytebuddy/build/gradle/PostCompilationAction.java
@@ -18,9 +18,6 @@ package net.bytebuddy.build.gradle;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.compile.AbstractCompile;
-import org.gradle.api.tasks.compile.JavaCompile;
-
-import java.lang.reflect.Method;
 
 /**
  * A compilation action that applies a class file transformation after a compilation task.
@@ -62,18 +59,6 @@ public class PostCompilationAction implements Action<AbstractCompile> {
      * {@inheritDoc}
      */
     public void execute(AbstractCompile task) {
-        if (byteBuddyExtension.implies(task)) {
-            if (task instanceof JavaCompile) {
-                try {
-                    Object options = JavaCompile.class.getMethod("getOptions").invoke(task);
-                    options.getClass().getMethod("setIncremental", boolean.class).invoke(options, false);
-                } catch (Throwable throwable) {
-                    project.getLogger().debug("Incremental build option not available for {}", task.getName(), throwable);
-                }
-            }
-            task.doLast(new TransformationAction(project, byteBuddyExtension, task));
-        } else {
-            project.getLogger().info("Skipping non-specified task {}", task.getName());
-        }
+        task.doLast(new TransformationAction(project, byteBuddyExtension, task));
     }
 }

--- a/byte-buddy-gradle-plugin/src/test/java/net/bytebuddy/build/gradle/PostCompilationActionTest.java
+++ b/byte-buddy-gradle-plugin/src/test/java/net/bytebuddy/build/gradle/PostCompilationActionTest.java
@@ -41,12 +41,4 @@ public class PostCompilationActionTest {
         new PostCompilationAction(project, byteBuddyExtension).execute(task);
         verify(task).doLast(any(TransformationAction.class));
     }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void testNoApplication() throws Exception {
-        when(byteBuddyExtension.implies(task)).thenReturn(false);
-        new PostCompilationAction(project, byteBuddyExtension).execute(task);
-        verify(task, never()).doLast(any(Action.class));
-    }
 }

--- a/byte-buddy-gradle-plugin/src/test/java/net/bytebuddy/build/gradle/TransformationActionTest.java
+++ b/byte-buddy-gradle-plugin/src/test/java/net/bytebuddy/build/gradle/TransformationActionTest.java
@@ -98,6 +98,8 @@ public class TransformationActionTest {
         });
         when(byteBuddyExtension.getMethodNameTransformer()).thenReturn(MethodNameTransformer.Suffixing.withRandomSuffix());
         when(transformation.makeArgumentResolvers()).thenReturn(Collections.<Plugin.Factory.UsingReflection.ArgumentResolver>emptyList());
+        when(task.getName()).thenReturn("compileJava");
+        when(byteBuddyExtension.implies(any(Task.class))).thenReturn(true);
         transformationAction = new TransformationAction(project, byteBuddyExtension, parent);
     }
 


### PR DESCRIPTION
The Project extension "ByteBuddyExtension" is handled by "lazy configuration", thus it not yet initialized when registering the PostCompilationAction. (see https://docs.gradle.org/current/userguide/lazy_configuration.html) thus the check with-> byteBuddyExtension.implies(task) check will encounter a null value in the tasks set, and actually register the TransformationAction always.

To fix it, I moved `byteBuddyExtension.implies(task)` from PostCompilationAction.execute to TransformationAction.apply.

Configuring an example project with:
```groovy
byteBuddy {
  transformation {
    plugin = "******Plugin"
  }
  tasks = ['compileJava'].toSet()
}
```
thereafter worked as expected.
