### PR TITLE
Fixes #957 by allowing static interface methods to be used as bootstrap methods for dynamic constants

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/utility/JavaConstant.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/utility/JavaConstant.java
@@ -1610,7 +1610,7 @@ public interface JavaConstant {
                     methodDescription.getDeclaringType().getInternalName(),
                     methodDescription.getInternalName(),
                     methodDescription.getDescriptor(),
-                    false));
+                    methodDescription.getDeclaringType().isInterface()));
             Iterator<TypeDescription> iterator = (methodDescription.isStatic() || methodDescription.isConstructor()
                     ? methodDescription.getParameters().asTypeList().asErasures()
                     : CompoundList.of(methodDescription.getDeclaringType(), methodDescription.getParameters().asTypeList().asErasures())).iterator();


### PR DESCRIPTION
Signed-off-by: Laird Nelson <ljnelson@gmail.com>