### PR TITLE
Fix class injection for legacy classloaders which use getPackage internally on JDK9+

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/dynamic/loading/ClassInjector.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/dynamic/loading/ClassInjector.java
@@ -561,7 +561,6 @@ public interface ClassInjector {
                     if (JavaModule.isSupported()) { // Avoid accidental lookup of method with same name in Java 8 J9 VM.
                         try {
                             getDefinedPackage = ClassLoader.class.getMethod("getDefinedPackage", String.class);
-                            getDefinedPackage.setAccessible(true);
                         } catch (NoSuchMethodException ignored) {
                             getDefinedPackage = null;
                         }
@@ -1154,7 +1153,6 @@ public interface ClassInjector {
                     if (JavaModule.isSupported()) { // Avoid accidental lookup of method with same name in Java 8 J9 VM.
                         try {
                             getDefinedPackage = ClassLoader.class.getMethod("getDefinedPackage", String.class);
-                            putBoolean.invoke(unsafe, getDefinedPackage, offset, true);
                         } catch (NoSuchMethodException ignored) {
                             getDefinedPackage = null;
                         }

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/dynamic/loading/ClassInjectorUsingReflectionTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/dynamic/loading/ClassInjectorUsingReflectionTest.java
@@ -62,9 +62,9 @@ public class ClassInjectorUsingReflectionTest {
     public void testInjectionOnLegacyClassloader() throws Exception {
         ClassLoader classLoader = new LegacyGetPackageClassLoader();
         new ClassInjector.UsingReflection(classLoader.getParent()).inject(Collections.singletonMap(TypeDescription.ForLoadedType.of(Foo.class),
-            ClassFileLocator.ForClassLoader.read(Foo.class)));
+                ClassFileLocator.ForClassLoader.read(Foo.class)));
         new ClassInjector.UsingReflection(classLoader).inject(Collections.singletonMap(TypeDescription.ForLoadedType.of(Foo.class),
-            ClassFileLocator.ForClassLoader.read(Foo.class)));
+                ClassFileLocator.ForClassLoader.read(Foo.class)));
         assertThat(classLoader.loadClass(Foo.class.getName()).getClassLoader(), is(classLoader));
     }
 

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/test/utility/LegacyGetPackageClassLoader.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/test/utility/LegacyGetPackageClassLoader.java
@@ -1,0 +1,32 @@
+package net.bytebuddy.test.utility;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.jar.Manifest;
+
+/**
+ * Simulates a classloader that checks if a package is already defined with a call to getPackage. This causes
+ * definePackage to throw if an ancestor classloader already has it, and getDefinedPackage (JDK9+) is available since
+ * getDefinedPackage is the preferred way to check if the package can be defined.
+ */
+public class LegacyGetPackageClassLoader extends URLClassLoader {
+    public LegacyGetPackageClassLoader() {
+        super(new URL[0], new URLClassLoader(new URL[0], null));
+    }
+
+    @Override
+    protected Package definePackage(String name, Manifest man, URL url) throws IllegalArgumentException {
+        if (getPackage(name) != null) {
+            throw new IllegalArgumentException(name);
+        }
+        return super.definePackage(name, man, url);
+    }
+
+    @Override
+    protected Package definePackage(String name, String specTitle, String specVersion, String specVendor, String implTitle, String implVersion, String implVendor, URL sealBase) throws IllegalArgumentException {
+        if (getPackage(name) != null) {
+            throw new IllegalArgumentException(name);
+        }
+        return super.definePackage(name, specTitle, specVersion, specVendor, implTitle, implVersion, implVendor, sealBase);
+    }
+}


### PR DESCRIPTION
The old behavior of checking if a package is already defined in `ClassLoader#definePackage` was to rely on `getPackage` which asks the parent classloader if it was not found to be defined in the current one. This changed with JDK9 - now it is checked only against packages defined in the same classloader.

However, some custom classloaders (encountered the issue on WLS14+JDK11 combination, in its `GenericClassLoader`) which were originally written for JDK<9 still override the `definePackage` with the legacy behavior. This makes the `getDefinedPackage` check return null, but `definePackage` will still fail because it finds that the package already exists via `getPackage`.

In this case, the only recourse seems to be to consider this case as a success - call `getPackage` to verify the package exists in an ancestor and then check that it is compatible. Unfortunately this means that both `getDefinedPackage` and `getPackage` need to be available, meaning one extra field in several classes.

Could not find a reason for the `getPackage.setAccessible` to be called in `UsingUnsafeInjection.make`. It seems like it was unnecessary as that `Method` instance is not directly invoked, the method is only accessed through the generated accessor, and it is not done there for other methods with identical access modifiers.