### PR TITLE
Tweak m2e configuration to let the Maven plugin run on incremental builds as well.

### DIFF
--- a/byte-buddy-maven-plugin/pom.xml
+++ b/byte-buddy-maven-plugin/pom.xml
@@ -55,6 +55,11 @@
             <version>${version.maven.aether}</version>
         </dependency>
         <dependency>
+            <groupId>org.sonatype.plexus</groupId>
+            <artifactId>plexus-build-api</artifactId>
+            <version>0.0.7</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${version.junit}</version>

--- a/byte-buddy-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/byte-buddy-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -8,7 +8,10 @@
         </goals>
       </pluginExecutionFilter>
       <action>
-        <execute />
+        <execute>
+          <runOnIncremental>true</runOnIncremental>
+          <runOnConfiguration>true</runOnConfiguration>
+        </execute>
       </action>
     </pluginExecution>
   </pluginExecutions>


### PR DESCRIPTION
Prior to this change, when editing sources in Eclipse and saving the source file, the transformations registered by the plugin would not run and thus leave the classes in invalid state until a complete project refresh was triggered.