### PR TITLE
Matcher deduplication

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/matcher/BooleanMatcher.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/matcher/BooleanMatcher.java
@@ -25,6 +25,19 @@ import net.bytebuddy.build.HashCodeAndEqualsPlugin;
 @HashCodeAndEqualsPlugin.Enhance
 public class BooleanMatcher<T> extends ElementMatcher.Junction.AbstractBase<T> {
 
+    private static final BooleanMatcher<?> TRUE = new BooleanMatcher<Object>(true);
+    private static final BooleanMatcher<?> FALSE = new BooleanMatcher<Object>(false);
+
+    /**
+     * Returns boolean element matcher.
+     *
+     * @param matches The predefined result.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> BooleanMatcher<T> of(boolean matches) {
+        return (BooleanMatcher<T>) (matches ? TRUE : FALSE);
+    }
+
     /**
      * The predefined result.
      */

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/matcher/ElementMatchers.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/matcher/ElementMatchers.java
@@ -255,7 +255,7 @@ public final class ElementMatchers {
      * @return A matcher for a {@code mandated} parameter.
      */
     public static <T extends ParameterDescription> ElementMatcher.Junction<T> isMandated() {
-        return new ModifierMatcher<T>(ModifierMatcher.Mode.MANDATED);
+        return ModifierMatcher.of(ModifierMatcher.Mode.MANDATED);
     }
 
     /**
@@ -898,7 +898,7 @@ public final class ElementMatchers {
      * @return A matcher for a {@code abstract} modifier reviewable.
      */
     public static <T extends ModifierReviewable.OfAbstraction> ElementMatcher.Junction<T> isAbstract() {
-        return new ModifierMatcher<T>(ModifierMatcher.Mode.ABSTRACT);
+        return ModifierMatcher.of(ModifierMatcher.Mode.ABSTRACT);
     }
 
     /**
@@ -908,7 +908,7 @@ public final class ElementMatchers {
      * @return A matcher for an enum.
      */
     public static <T extends ModifierReviewable.OfEnumeration> ElementMatcher.Junction<T> isEnum() {
-        return new ModifierMatcher<T>(ModifierMatcher.Mode.ENUMERATION);
+        return ModifierMatcher.of(ModifierMatcher.Mode.ENUMERATION);
     }
 
     /**
@@ -975,7 +975,7 @@ public final class ElementMatchers {
      * @return A matcher for a {@code public} modifier reviewable.
      */
     public static <T extends ModifierReviewable.OfByteCodeElement> ElementMatcher.Junction<T> isPublic() {
-        return new ModifierMatcher<T>(ModifierMatcher.Mode.PUBLIC);
+        return ModifierMatcher.of(ModifierMatcher.Mode.PUBLIC);
     }
 
     /**
@@ -985,7 +985,7 @@ public final class ElementMatchers {
      * @return A matcher for a {@code protected} modifier reviewable.
      */
     public static <T extends ModifierReviewable.OfByteCodeElement> ElementMatcher.Junction<T> isProtected() {
-        return new ModifierMatcher<T>(ModifierMatcher.Mode.PROTECTED);
+        return ModifierMatcher.of(ModifierMatcher.Mode.PROTECTED);
     }
 
     /**
@@ -1005,7 +1005,7 @@ public final class ElementMatchers {
      * @return A matcher for a {@code private} modifier reviewable.
      */
     public static <T extends ModifierReviewable.OfByteCodeElement> ElementMatcher.Junction<T> isPrivate() {
-        return new ModifierMatcher<T>(ModifierMatcher.Mode.PRIVATE);
+        return ModifierMatcher.of(ModifierMatcher.Mode.PRIVATE);
     }
 
     /**
@@ -1015,7 +1015,7 @@ public final class ElementMatchers {
      * @return A matcher for a {@code static} modifier reviewable.
      */
     public static <T extends ModifierReviewable.OfByteCodeElement> ElementMatcher.Junction<T> isStatic() {
-        return new ModifierMatcher<T>(ModifierMatcher.Mode.STATIC);
+        return ModifierMatcher.of(ModifierMatcher.Mode.STATIC);
     }
 
     /**
@@ -1025,7 +1025,7 @@ public final class ElementMatchers {
      * @return A matcher for a {@code final} modifier reviewable.
      */
     public static <T extends ModifierReviewable> ElementMatcher.Junction<T> isFinal() {
-        return new ModifierMatcher<T>(ModifierMatcher.Mode.FINAL);
+        return ModifierMatcher.of(ModifierMatcher.Mode.FINAL);
     }
 
     /**
@@ -1035,7 +1035,7 @@ public final class ElementMatchers {
      * @return A matcher for a synthetic modifier reviewable.
      */
     public static <T extends ModifierReviewable> ElementMatcher.Junction<T> isSynthetic() {
-        return new ModifierMatcher<T>(ModifierMatcher.Mode.SYNTHETIC);
+        return ModifierMatcher.of(ModifierMatcher.Mode.SYNTHETIC);
     }
 
     /**
@@ -1045,7 +1045,7 @@ public final class ElementMatchers {
      * @return A matcher for a {@code synchronized} method description.
      */
     public static <T extends ModifierReviewable.ForMethodDescription> ElementMatcher.Junction<T> isSynchronized() {
-        return new ModifierMatcher<T>(ModifierMatcher.Mode.SYNCHRONIZED);
+        return ModifierMatcher.of(ModifierMatcher.Mode.SYNCHRONIZED);
     }
 
     /**
@@ -1055,7 +1055,7 @@ public final class ElementMatchers {
      * @return A matcher for a {@code native} method description.
      */
     public static <T extends ModifierReviewable.ForMethodDescription> ElementMatcher.Junction<T> isNative() {
-        return new ModifierMatcher<T>(ModifierMatcher.Mode.NATIVE);
+        return ModifierMatcher.of(ModifierMatcher.Mode.NATIVE);
     }
 
     /**
@@ -1065,7 +1065,7 @@ public final class ElementMatchers {
      * @return A matcher for a {@code strictfp} method description.
      */
     public static <T extends ModifierReviewable.ForMethodDescription> ElementMatcher.Junction<T> isStrict() {
-        return new ModifierMatcher<T>(ModifierMatcher.Mode.STRICT);
+        return ModifierMatcher.of(ModifierMatcher.Mode.STRICT);
     }
 
     /**
@@ -1075,7 +1075,7 @@ public final class ElementMatchers {
      * @return A matcher for a var-args method description.
      */
     public static <T extends ModifierReviewable.ForMethodDescription> ElementMatcher.Junction<T> isVarArgs() {
-        return new ModifierMatcher<T>(ModifierMatcher.Mode.VAR_ARGS);
+        return ModifierMatcher.of(ModifierMatcher.Mode.VAR_ARGS);
     }
 
     /**
@@ -1085,7 +1085,7 @@ public final class ElementMatchers {
      * @return A matcher for a bridge method.
      */
     public static <T extends ModifierReviewable.ForMethodDescription> ElementMatcher.Junction<T> isBridge() {
-        return new ModifierMatcher<T>(ModifierMatcher.Mode.BRIDGE);
+        return ModifierMatcher.of(ModifierMatcher.Mode.BRIDGE);
     }
 
     /**
@@ -1523,7 +1523,7 @@ public final class ElementMatchers {
      * @see ElementMatchers#isAnnotation()
      */
     public static <T extends TypeDescription> ElementMatcher.Junction<T> isInterface() {
-        return new ModifierMatcher<T>(ModifierMatcher.Mode.INTERFACE);
+        return ModifierMatcher.of(ModifierMatcher.Mode.INTERFACE);
     }
 
     /**
@@ -1533,7 +1533,7 @@ public final class ElementMatchers {
      * @return A matcher for an annotation type.
      */
     public static <T extends TypeDescription> ElementMatcher.Junction<T> isAnnotation() {
-        return new ModifierMatcher<T>(ModifierMatcher.Mode.ANNOTATION);
+        return ModifierMatcher.of(ModifierMatcher.Mode.ANNOTATION);
     }
 
     /**
@@ -2148,7 +2148,7 @@ public final class ElementMatchers {
      * @return A matcher for a {@code volatile} field.
      */
     public static <T extends FieldDescription> ElementMatcher.Junction<T> isVolatile() {
-        return new ModifierMatcher<T>(ModifierMatcher.Mode.VOLATILE);
+        return ModifierMatcher.of(ModifierMatcher.Mode.VOLATILE);
     }
 
     /**
@@ -2158,7 +2158,7 @@ public final class ElementMatchers {
      * @return A matcher for a {@code transient} field.
      */
     public static <T extends FieldDescription> ElementMatcher.Junction<T> isTransient() {
-        return new ModifierMatcher<T>(ModifierMatcher.Mode.TRANSIENT);
+        return ModifierMatcher.of(ModifierMatcher.Mode.TRANSIENT);
     }
 
     /**

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/matcher/ElementMatchers.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/matcher/ElementMatchers.java
@@ -298,7 +298,7 @@ public final class ElementMatchers {
      * @return A matcher that matches anything.
      */
     public static <T> ElementMatcher.Junction<T> any() {
-        return new BooleanMatcher<T>(true);
+        return BooleanMatcher.of(true);
     }
 
     /**
@@ -308,7 +308,7 @@ public final class ElementMatchers {
      * @return A matcher that matches nothing.
      */
     public static <T> ElementMatcher.Junction<T> none() {
-        return new BooleanMatcher<T>(false);
+        return BooleanMatcher.of(false);
     }
 
     /**
@@ -1379,7 +1379,7 @@ public final class ElementMatchers {
      */
     public static <T extends MethodDescription> ElementMatcher.Junction<T> canThrow(TypeDescription exceptionType) {
         return exceptionType.isAssignableTo(RuntimeException.class) || exceptionType.isAssignableTo(Error.class)
-                ? new BooleanMatcher<T>(true)
+                ? BooleanMatcher.<T>of(true)
                 : ElementMatchers.<T>declaresGenericException(new CollectionItemMatcher<TypeDescription.Generic>(erasure(isSuperTypeOf(exceptionType))));
     }
 
@@ -1408,7 +1408,7 @@ public final class ElementMatchers {
     public static <T extends MethodDescription> ElementMatcher.Junction<T> declaresGenericException(TypeDescription.Generic exceptionType) {
         return !exceptionType.getSort().isWildcard() && exceptionType.asErasure().isAssignableTo(Throwable.class)
                 ? ElementMatchers.<T>declaresGenericException(new CollectionItemMatcher<TypeDescription.Generic>(is(exceptionType)))
-                : new BooleanMatcher<T>(false);
+                : BooleanMatcher.<T>of(false);
     }
 
     /**
@@ -1432,7 +1432,7 @@ public final class ElementMatchers {
     public static <T extends MethodDescription> ElementMatcher.Junction<T> declaresException(TypeDescription exceptionType) {
         return exceptionType.isAssignableTo(Throwable.class)
                 ? ElementMatchers.<T>declaresGenericException(new CollectionItemMatcher<TypeDescription.Generic>(erasure(exceptionType)))
-                : new BooleanMatcher<T>(false);
+                : BooleanMatcher.<T>of(false);
     }
 
     /**
@@ -2251,7 +2251,7 @@ public final class ElementMatchers {
      */
     public static <T extends ClassLoader> ElementMatcher.Junction<T> isChildOf(ClassLoader classLoader) {
         return classLoader == BOOTSTRAP_CLASSLOADER
-                ? new BooleanMatcher<T>(true)
+                ? BooleanMatcher.<T>of(true)
                 : ElementMatchers.<T>hasChild(is(classLoader));
     }
 

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/matcher/ElementMatchers.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/matcher/ElementMatchers.java
@@ -123,7 +123,7 @@ public final class ElementMatchers {
      */
     public static <T> ElementMatcher.Junction<T> is(Object value) {
         return value == null
-                ? new NullMatcher<T>()
+                ? NullMatcher.<T>of()
                 : new EqualityMatcher<T>(value);
     }
 
@@ -2213,7 +2213,7 @@ public final class ElementMatchers {
      * @return A matcher that only matches the bootstrap class loader.
      */
     public static <T extends ClassLoader> ElementMatcher.Junction<T> isBootstrapClassLoader() {
-        return new NullMatcher<T>();
+        return NullMatcher.of();
     }
 
     /**
@@ -2298,6 +2298,6 @@ public final class ElementMatchers {
      * @return A matcher that validates a module's existence.
      */
     public static <T extends JavaModule> ElementMatcher.Junction<T> supportsModules() {
-        return not(new NullMatcher<T>());
+        return not(NullMatcher.of());
     }
 }

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/matcher/ElementMatchers.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/matcher/ElementMatchers.java
@@ -1543,7 +1543,7 @@ public final class ElementMatchers {
      * @return A matcher that only matches method descriptions that represent a Java method.
      */
     public static <T extends MethodDescription> ElementMatcher.Junction<T> isMethod() {
-        return new MethodSortMatcher<T>(MethodSortMatcher.Sort.METHOD);
+        return MethodSortMatcher.of(MethodSortMatcher.Sort.METHOD);
     }
 
     /**
@@ -1553,7 +1553,7 @@ public final class ElementMatchers {
      * @return A matcher that only matches method descriptions that represent a Java constructor.
      */
     public static <T extends MethodDescription> ElementMatcher.Junction<T> isConstructor() {
-        return new MethodSortMatcher<T>(MethodSortMatcher.Sort.CONSTRUCTOR);
+        return MethodSortMatcher.of(MethodSortMatcher.Sort.CONSTRUCTOR);
     }
 
     /**
@@ -1563,7 +1563,7 @@ public final class ElementMatchers {
      * @return A matcher that only matches method descriptions that represent the type initializer.
      */
     public static <T extends MethodDescription> ElementMatcher.Junction<T> isTypeInitializer() {
-        return new MethodSortMatcher<T>(MethodSortMatcher.Sort.TYPE_INITIALIZER);
+        return MethodSortMatcher.of(MethodSortMatcher.Sort.TYPE_INITIALIZER);
     }
 
     /**
@@ -1573,7 +1573,7 @@ public final class ElementMatchers {
      * @return A matcher for virtual methods.
      */
     public static <T extends MethodDescription> ElementMatcher.Junction<T> isVirtual() {
-        return new MethodSortMatcher<T>(MethodSortMatcher.Sort.VIRTUAL);
+        return MethodSortMatcher.of(MethodSortMatcher.Sort.VIRTUAL);
     }
 
     /**
@@ -1583,7 +1583,7 @@ public final class ElementMatchers {
      * @return A matcher that only matches Java 8 default methods.
      */
     public static <T extends MethodDescription> ElementMatcher.Junction<T> isDefaultMethod() {
-        return new MethodSortMatcher<T>(MethodSortMatcher.Sort.DEFAULT_METHOD);
+        return MethodSortMatcher.of(MethodSortMatcher.Sort.DEFAULT_METHOD);
     }
 
     /**

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/matcher/MethodSortMatcher.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/matcher/MethodSortMatcher.java
@@ -28,6 +28,16 @@ import net.bytebuddy.description.method.MethodDescription;
 public class MethodSortMatcher<T extends MethodDescription> extends ElementMatcher.Junction.AbstractBase<T> {
 
     /**
+     * Returns an element matcher that matches a specific sort of method description.
+     *
+     * @param sort The sort of method description to be matched by this element matcher.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T extends MethodDescription> MethodSortMatcher<T> of(Sort sort) {
+        return (MethodSortMatcher<T>) sort.matcher;
+    }
+
+    /**
      * The sort of method description to be matched by this element matcher.
      */
     private final Sort sort;
@@ -114,6 +124,8 @@ public class MethodSortMatcher<T extends MethodDescription> extends ElementMatch
          */
         private final String description;
 
+        private final MethodSortMatcher<?> matcher;
+
         /**
          * Creates a new method sort representation.
          *
@@ -121,6 +133,7 @@ public class MethodSortMatcher<T extends MethodDescription> extends ElementMatch
          */
         Sort(String description) {
             this.description = description;
+            this.matcher = new MethodSortMatcher<MethodDescription>(this);
         }
 
         /**

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/matcher/ModifierMatcher.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/matcher/ModifierMatcher.java
@@ -28,6 +28,16 @@ import org.objectweb.asm.Opcodes;
 public class ModifierMatcher<T extends ModifierReviewable> extends ElementMatcher.Junction.AbstractBase<T> {
 
     /**
+     * Returns a new element matcher that matches an element by its modifier.
+     *
+     * @param mode The match mode to apply to the matched element's modifier.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T extends ModifierReviewable> ModifierMatcher<T> of(Mode mode) {
+        return (ModifierMatcher<T>) mode.matcher;
+    }
+
+    /**
      * The matching mode to apply by this modifier matcher.
      */
     private final Mode mode;
@@ -159,6 +169,11 @@ public class ModifierMatcher<T extends ModifierReviewable> extends ElementMatche
         private final String description;
 
         /**
+         * The canonical matcher instance.
+         */
+        private final ModifierMatcher<?> matcher;
+
+        /**
          * Creates a new modifier matcher mode.
          *
          * @param modifiers   The mask of the modifier to match.
@@ -167,6 +182,7 @@ public class ModifierMatcher<T extends ModifierReviewable> extends ElementMatche
         Mode(int modifiers, String description) {
             this.modifiers = modifiers;
             this.description = description;
+            this.matcher = new ModifierMatcher<ModifierReviewable>(this);
         }
 
         /**

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/matcher/NullMatcher.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/matcher/NullMatcher.java
@@ -25,6 +25,13 @@ import net.bytebuddy.build.HashCodeAndEqualsPlugin;
 @HashCodeAndEqualsPlugin.Enhance
 public class NullMatcher<T> extends ElementMatcher.Junction.AbstractBase<T> {
 
+    private static final NullMatcher<?> INSTANCE = new NullMatcher<Object>();
+
+    @SuppressWarnings("unchecked")
+    public static <T> NullMatcher<T> of() {
+        return (NullMatcher<T>) INSTANCE;
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/matcher/BooleanMatcherTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/matcher/BooleanMatcherTest.java
@@ -33,4 +33,10 @@ public class BooleanMatcherTest extends AbstractElementMatcherTest<BooleanMatche
         assertThat(new BooleanMatcher<Object>(true).toString(), is("true"));
         assertThat(new BooleanMatcher<Object>(false).toString(), is("false"));
     }
+
+    @Test
+    public void testSingletonEquivalentToNewInstance() {
+        assertThat(BooleanMatcher.of(true), is(new BooleanMatcher<Object>(true)));
+        assertThat(BooleanMatcher.of(false), is(new BooleanMatcher<Object>(false)));
+    }
 }

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/matcher/MethodSortMatcherTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/matcher/MethodSortMatcherTest.java
@@ -59,6 +59,11 @@ public class MethodSortMatcherTest extends AbstractElementMatcherTest<MethodSort
         assertThat(new MethodSortMatcher<MethodDescription>(sort).toString(), is(sort.getDescription()));
     }
 
+    @Test
+    public void testSingletonIsEquivalentToNewInstance() {
+        assertThat(MethodSortMatcher.of(sort), is(new MethodSortMatcher<MethodDescription>(sort)));
+    }
+
     private enum MockImplementation {
 
         CONSTRUCTOR {

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/matcher/ModifierMatcherTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/matcher/ModifierMatcherTest.java
@@ -73,4 +73,9 @@ public class ModifierMatcherTest extends AbstractElementMatcherTest<ModifierMatc
     public void testStringRepresentation() throws Exception {
         assertThat(new ModifierMatcher<ModifierReviewable>(mode).toString(), is(mode.getDescription()));
     }
+
+    @Test
+    public void testSingletonEquivalentToNewInstance() {
+        assertThat(ModifierMatcher.of(mode), is(new ModifierMatcher<ModifierReviewable>(mode)));
+    }
 }

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/matcher/NullMatcherTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/matcher/NullMatcherTest.java
@@ -21,4 +21,9 @@ public class NullMatcherTest extends AbstractElementMatcherTest<NullMatcher<?>> 
     public void testPositiveToNegative() throws Exception {
         assertThat(new NullMatcher<Object>().matches(new Object()), is(false));
     }
+
+    @Test
+    public void testSingletonIsEquivalentToNewInstance() {
+        assertThat(NullMatcher.of(), is(new NullMatcher<Object>()));
+    }
 }


### PR DESCRIPTION
This is small effort towards reducing the footprint of the matching system. Since none of these matchers are data dependent, they can be singletons. In the Datadog agent with default settings (as a concrete use case), during startup we allocate 27768B of `MethodSortMatcher` and 11328B of `ModifierMatcher` during bootstrapping. `BooleanMatcher` accounts for another 17KB. Allocating all of these once when the `Sort` and `Mode` enums are loaded eliminates this. It's not a huge impact but I think it's a worthwhile change, has no downsides, and composes additively with any other footprint improvements. 

Deduplicates most static cardinality matchers
* `ModifierMatcher`
* `MethodSortMatcher`
* `BooleanMatcher`
* `NullMatcher`