### PR TITLE
fix MethodCall.construct().setsFields() validation fail due to false assignment error

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/MethodCall.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/MethodCall.java
@@ -3096,7 +3096,9 @@ public class MethodCall implements Implementation.Composable {
              * {@inheritDoc}
              */
             public StackManipulation toStackManipulation(MethodDescription invokedMethod, MethodDescription instrumentedMethod, Assigner assigner, Assigner.Typing typing) {
-                StackManipulation stackManipulation = assigner.assign(invokedMethod.getReturnType(), fieldDescription.getType(), typing);
+                StackManipulation stackManipulation = assigner.assign(invokedMethod.isConstructor()
+                        ? invokedMethod.getDeclaringType().asGenericType()
+                        : invokedMethod.getReturnType(), fieldDescription.getType(), typing);
                 if (!stackManipulation.isValid()) {
                     throw new IllegalStateException("Cannot assign result of " + invokedMethod + " to " + fieldDescription);
                 }


### PR DESCRIPTION
This simple code snippet of a constructor call and then store into a field fails validation:
```Java
MethodCall.construct(ConstructorResult.Target.class.getConstructor())
                        .setsField(ElementMatchers.named("field")
```

The Exception thrown:
```
java.lang.IllegalStateException: Cannot assign result of public net.bytebuddy.implementation.MethodCallTest$ConstructorResult$Target() to public net.bytebuddy.implementation.MethodCallTest$ConstructorResult$Target net.bytebuddy.implementation.MethodCallTest$ConstructorResult.field
	at net.bytebuddy.implementation.MethodCall$TerminationHandler$FieldSetting.toStackManipulation(MethodCall.java:3101)
	at net.bytebuddy.implementation.MethodCall$Appender.toStackManipulation(MethodCall.java:3565)
	at net.bytebuddy.implementation.MethodCall$Appender.apply(MethodCall.java:3523)
	at net.bytebuddy.implementation.bytecode.ByteCodeAppender$Compound.apply(ByteCodeAppender.java:151)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$MethodPool$Record$ForDefinedMethod$WithBody.applyCode(TypeWriter.java:708)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$MethodPool$Record$ForDefinedMethod$WithBody.applyBody(TypeWriter.java:693)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$MethodPool$Record$ForDefinedMethod.apply(TypeWriter.java:600)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$Default$ForCreation.create(TypeWriter.java:5751)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$Default.make(TypeWriter.java:2166)
	at net.bytebuddy.dynamic.scaffold.subclass.SubclassDynamicTypeBuilder.make(SubclassDynamicTypeBuilder.java:232)
	at net.bytebuddy.dynamic.scaffold.subclass.SubclassDynamicTypeBuilder.make(SubclassDynamicTypeBuilder.java:204)
	at net.bytebuddy.dynamic.DynamicType$Builder$AbstractBase.make(DynamicType.java:3659)
	at net.bytebuddy.dynamic.DynamicType$Builder$AbstractBase$Delegator.make(DynamicType.java:3897)
	at net.bytebuddy.implementation.MethodCallTest.testConstructorCallResultIntoField(MethodCallTest.java:1306)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:64)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:564)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
```

The issue is that in commit 2bccd69b3c662c808eedc11cca1fd017bba0202a the `.withMethodCall(construct())` path got fixed but `construct().setsField()` is missing the adjustment and causes the exception. This MR simply "copies" the changes from that commit and applies it to `.setsFields()`. The first commit adds 2 tests of that 1 fails and the second commit adds the fix.