### PR TITLE
collapse logical conjunction and disjunction raw matchers

### DIFF
--- a/byte-buddy-dep/src/test/java/net/bytebuddy/matcher/ElementMatcherJunctionConjunctionTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/matcher/ElementMatcherJunctionConjunctionTest.java
@@ -56,4 +56,80 @@ public class ElementMatcherJunctionConjunctionTest extends AbstractElementMatche
     public void testToString() {
         assertThat(new ElementMatcher.Junction.Conjunction<Object>(first, second).toString(), CoreMatchers.containsString(" and "));
     }
+
+    @Test
+    public void testInlineLeftMatches() {
+        Object target = new Object();
+        when(first.matches(target)).thenReturn(true);
+        when(second.matches(target)).thenReturn(true);
+        ElementMatcher.Junction.Conjunction<Object> leaf = new ElementMatcher.Junction.Conjunction<Object>(first, ElementMatchers.any());
+        assertThat(new ElementMatcher.Junction.Conjunction<Object>(leaf, second).matches(target), is(true));
+        verify(first).matches(target);
+        verifyNoMoreInteractions(first);
+        verify(second).matches(target);
+        verifyNoMoreInteractions(second);
+    }
+
+    @Test
+    public void testInlineRightMatches() {
+        Object target = new Object();
+        when(first.matches(target)).thenReturn(true);
+        when(second.matches(target)).thenReturn(true);
+        ElementMatcher.Junction.Conjunction<Object> leaf = new ElementMatcher.Junction.Conjunction<Object>(second, ElementMatchers.any());
+        assertThat(new ElementMatcher.Junction.Conjunction<Object>(first, leaf).matches(target), is(true));
+        verify(first).matches(target);
+        verifyNoMoreInteractions(first);
+        verify(second).matches(target);
+        verifyNoMoreInteractions(second);
+    }
+
+    @Test
+    public void testInlineLeftNotMatches() {
+        Object target = new Object();
+        when(first.matches(target)).thenReturn(true);
+        when(second.matches(target)).thenReturn(false);
+        ElementMatcher.Junction.Conjunction<Object> leaf = new ElementMatcher.Junction.Conjunction<Object>(first, ElementMatchers.any());
+        assertThat(new ElementMatcher.Junction.Conjunction<Object>(leaf, second).matches(target), is(false));
+        verify(first).matches(target);
+        verifyNoMoreInteractions(first);
+        verify(second).matches(target);
+        verifyNoMoreInteractions(second);
+    }
+
+    @Test
+    public void testInlineLeftChildNotMatches() {
+        Object target = new Object();
+        when(first.matches(target)).thenReturn(true);
+        when(second.matches(target)).thenReturn(true);
+        ElementMatcher.Junction.Conjunction<Object> leaf = new ElementMatcher.Junction.Conjunction<Object>(first, ElementMatchers.none());
+        assertThat(new ElementMatcher.Junction.Conjunction<Object>(leaf, second).matches(target), is(false));
+        verify(first).matches(target);
+        verifyNoMoreInteractions(first);
+        verifyNoMoreInteractions(second);
+    }
+
+    @Test
+    public void testInlineRightNotMatches() {
+        Object target = new Object();
+        when(first.matches(target)).thenReturn(true);
+        when(second.matches(target)).thenReturn(false);
+        ElementMatcher.Junction.Conjunction<Object> leaf = new ElementMatcher.Junction.Conjunction<Object>(second, ElementMatchers.any());
+        assertThat(new ElementMatcher.Junction.Conjunction<Object>(first, leaf).matches(target), is(false));
+        verify(first).matches(target);
+        verifyNoMoreInteractions(first);
+        verify(second).matches(target);
+        verifyNoMoreInteractions(second);
+    }
+
+    @Test
+    public void testInlineRightChildNotMatches() {
+        Object target = new Object();
+        when(first.matches(target)).thenReturn(true);
+        when(second.matches(target)).thenReturn(true);
+        ElementMatcher.Junction.Conjunction<Object> leaf = new ElementMatcher.Junction.Conjunction<Object>(ElementMatchers.none(), second);
+        assertThat(new ElementMatcher.Junction.Conjunction<Object>(first, leaf).matches(target), is(false));
+        verify(first).matches(target);
+        verifyNoMoreInteractions(first);
+        verifyNoMoreInteractions(second);
+    }
 }

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/matcher/ElementMatcherJunctionDisjunctionTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/matcher/ElementMatcherJunctionDisjunctionTest.java
@@ -56,4 +56,55 @@ public class ElementMatcherJunctionDisjunctionTest extends AbstractElementMatche
     public void testToString() {
         assertThat(new ElementMatcher.Junction.Disjunction<Object>(first, second).toString(), CoreMatchers.containsString(" or "));
     }
+
+    @Test
+    public void testInlineLeftMatches() {
+        Object target = new Object();
+        when(first.matches(target)).thenReturn(true);
+        when(second.matches(target)).thenReturn(true);
+        ElementMatcher.Junction.Disjunction<Object> leaf = new ElementMatcher.Junction.Disjunction<Object>(first, ElementMatchers.any());
+        assertThat(new ElementMatcher.Junction.Disjunction<Object>(leaf, second).matches(target), is(true));
+        verify(first).matches(target);
+        verifyNoMoreInteractions(first);
+        verifyNoMoreInteractions(second);
+    }
+
+    @Test
+    public void testInlineLeftChildMatches() {
+        Object target = new Object();
+        when(first.matches(target)).thenReturn(false);
+        when(second.matches(target)).thenReturn(true);
+        ElementMatcher.Junction.Disjunction<Object> leaf = new ElementMatcher.Junction.Disjunction<Object>(first, second);
+        assertThat(new ElementMatcher.Junction.Disjunction<Object>(leaf, second).matches(target), is(true));
+        verify(first).matches(target);
+        verifyNoMoreInteractions(first);
+        verify(second).matches(target);
+        verifyNoMoreInteractions(second);
+    }
+
+    @Test
+    public void testInlineRightFirstMatches() {
+        Object target = new Object();
+        when(first.matches(target)).thenReturn(false);
+        when(second.matches(target)).thenReturn(true);
+        ElementMatcher.Junction.Disjunction<Object> leaf = new ElementMatcher.Junction.Disjunction<Object>(second, ElementMatchers.any());
+        assertThat(new ElementMatcher.Junction.Disjunction<Object>(first, leaf).matches(target), is(true));
+        verify(first).matches(target);
+        verifyNoMoreInteractions(first);
+        verify(second).matches(target);
+        verifyNoMoreInteractions(second);
+    }
+
+    @Test
+    public void testInlineRightSecondMatches() {
+        Object target = new Object();
+        when(first.matches(target)).thenReturn(false);
+        when(second.matches(target)).thenReturn(true);
+        ElementMatcher.Junction.Disjunction<Object> leaf = new ElementMatcher.Junction.Disjunction<Object>(ElementMatchers.none(), second);
+        assertThat(new ElementMatcher.Junction.Disjunction<Object>(first, leaf).matches(target), is(true));
+        verify(first).matches(target);
+        verifyNoMoreInteractions(first);
+        verify(second).matches(target);
+        verifyNoMoreInteractions(second);
+    }
 }


### PR DESCRIPTION
This is more to add colour to #1036 than submitted with an expectation to merge. Since the collapsing logic is the same for conjunctions and disjunctions, I merged the classes and differentiate them with an operation identifier.