### PR TITLE
Bump JNA dependency to v5.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <asm.url>https://asm.ow2.io</asm.url>
         <nexus.url>https://oss.sonatype.org</nexus.url>
         <version.asm>9.1</version.asm>
-        <jna.version>5.3.1</jna.version>
+        <jna.version>5.8.0</jna.version>
         <version.junit>4.13.2</version.junit>
         <version.mockito>2.23.0</version.mockito>
         <version.plugin.clean>3.0.0</version.plugin.clean>


### PR DESCRIPTION
Bump JNA dependency to v5.8.0 from v5.3.1 to attempt to add support for M1.

See [JNA's changelog](https://github.com/java-native-access/jna/blob/HEAD/CHANGES.md).