### PR TITLE
Add missing entries to module-info.java

### DIFF
--- a/byte-buddy/pom.xml
+++ b/byte-buddy/pom.xml
@@ -60,6 +60,7 @@
             net.bytebuddy.matcher,
             net.bytebuddy.pool,
             net.bytebuddy.utility,
+            net.bytebuddy.utility.dispatcher,
             net.bytebuddy.utility.privilege,
             net.bytebuddy.utility.visitor,
             ${shade.target},


### PR DESCRIPTION
If I understand correctly the commit message of d3993051f2efcb0cef5523e1638d4dd2bfe743d8 , the package `net.bytebuddy.utility.dispatcher` is API and thus should be exposed to other modules.

Regardless, if it isn't exposed, I get errors in Hibernate ORM tests when running tests in the module paths; see https://github.com/hibernate/hibernate-orm/pull/4082#issuecomment-874172474.