### PR TITLE
Fix typo

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/agent/builder/AgentBuilder.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/agent/builder/AgentBuilder.java
@@ -5252,7 +5252,7 @@ public interface AgentBuilder {
          * <p>
          * <b>Note</b>: When applying a redefinition, it is normally required to use a {@link TypeStrategy} that applies
          * a redefinition instead of rebasing classes such as {@link TypeStrategy.Default#REDEFINE}. Also, consider
-         * the constrains given by this type strategy.
+         * the constraints given by this type strategy.
          * </p>
          */
         REDEFINITION(true, false) {
@@ -5294,7 +5294,7 @@ public interface AgentBuilder {
          * <p>
          * <b>Note</b>: When applying a retransformation, it is normally required to use a {@link TypeStrategy} that applies
          * a redefinition instead of rebasing classes such as {@link TypeStrategy.Default#REDEFINE}. Also, consider
-         * the constrains given by this type strategy.
+         * the constraints given by this type strategy.
          * </p>
          */
         RETRANSFORMATION(true, true) {

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/dynamic/scaffold/TypeWriter.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/dynamic/scaffold/TypeWriter.java
@@ -2876,12 +2876,12 @@ public interface TypeWriter<T> {
                 enum ForInterface implements Constraint {
 
                     /**
-                     * An interface type with the constrains for the Java versions 5 to 7.
+                     * An interface type with the constraints for the Java versions 5 to 7.
                      */
                     CLASSIC(true),
 
                     /**
-                     * An interface type with the constrains for the Java versions 8+.
+                     * An interface type with the constraints for the Java versions 8+.
                      */
                     JAVA_8(false);
 
@@ -3171,12 +3171,12 @@ public interface TypeWriter<T> {
                 enum ForAnnotation implements Constraint {
 
                     /**
-                     * An annotation type with the constrains for the Java versions 5 to 7.
+                     * An annotation type with the constraints for the Java versions 5 to 7.
                      */
                     CLASSIC(true),
 
                     /**
-                     * An annotation type with the constrains for the Java versions 8+.
+                     * An annotation type with the constraints for the Java versions 8+.
                      */
                     JAVA_8(false);
 


### PR DESCRIPTION
Found this when looking at the Javadocs, gave it a look and found a few instances of the same typo in a couple of classes.

(Thanks for a _great_ Java library! This is my way to say "thank you" for all the awesome work you've done and continue doing over the years. :pray:)