### PR TITLE
Fix package name of JDK reflection in default ignore matcher

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/agent/builder/AgentBuilder.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/agent/builder/AgentBuilder.java
@@ -9401,7 +9401,7 @@ public interface AgentBuilder {
                             new RawMatcher.ForElementMatchers(any(), isBootstrapClassLoader().or(isExtensionClassLoader())),
                             new RawMatcher.ForElementMatchers(nameStartsWith("net.bytebuddy.")
                                     .and(not(ElementMatchers.nameStartsWith(NamingStrategy.SuffixingRandom.BYTE_BUDDY_RENAME_PACKAGE + ".")))
-                                    .or(nameStartsWith("sun.reflect.").or(nameStartsWith("jdk.reflect.")))
+                                    .or(nameStartsWith("sun.reflect.").or(nameStartsWith("jdk.internal.reflect.")))
                                     .<TypeDescription>or(isSynthetic()))),
                     Collections.<Transformation>emptyList());
         }


### PR DESCRIPTION
The new JDK reflection implementation is in `jdk.internal.reflect` and creates classes like `jdk.internal.reflect.GeneratedMethodAccessorXXX` (see [NativeMethodAccessorImpl](https://github.com/openjdk/jdk/blob/739769c8fc4b496f08a92225a12d07414537b6c0/src/java.base/share/classes/jdk/internal/reflect/NativeMethodAccessorImpl.java#L62) and [MethodAccessorGenerator](https://github.com/openjdk/jdk/blob/739769c8fc4b496f08a92225a12d07414537b6c0/src/java.base/share/classes/jdk/internal/reflect/MethodAccessorGenerator.java#L124)).