### PR TITLE
Continuation for issue https://github.com/raphw/byte-buddy/issues/1104

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/asm/Advice.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/asm/Advice.java
@@ -10903,6 +10903,12 @@ public class Advice implements AsmVisitorWrapper.ForDeclaredMethods.MethodVisito
      * <b>Important</b>: Parameters with this option must not be used when from a constructor in combination with
      * {@link OnMethodEnter} where the {@code this} reference is not available.
      * </p>
+     * <p>
+     * <b>Important</b>: Don't confuse this annotation with {@link net.bytebuddy.implementation.bind.annotation.This}
+     * annotation. This annotation should be used only in combination with {@link Advice} ASM visitor. For method
+     * delegation ({@link net.bytebuddy.implementation.MethodDelegation MethodDelegation.to(...)}) use alternative
+     * annotation from <code>net.bytebuddy.implementation.bind</code> package.
+     * </p>
      *
      * @see Advice
      * @see OnMethodEnter
@@ -10945,6 +10951,12 @@ public class Advice implements AsmVisitorWrapper.ForDeclaredMethods.MethodVisito
     /**
      * Indicates that the annotated parameter should be mapped to the parameter with index {@link Argument#value()} of
      * the instrumented method.
+     *
+     * <b>Important</b>: Don't confuse this annotation with {@link net.bytebuddy.implementation.bind.annotation.Argument}
+     * annotation. This annotation should be used only in combination with {@link Advice} ASM visitor. For method
+     * delegation ({@link net.bytebuddy.implementation.MethodDelegation MethodDelegation.to(...)}) use alternative
+     * annotation from <code>net.bytebuddy.implementation.bind</code> package.
+     * </p>
      *
      * @see Advice
      * @see OnMethodEnter
@@ -10996,6 +11008,12 @@ public class Advice implements AsmVisitorWrapper.ForDeclaredMethods.MethodVisito
      * Assigns an array containing all arguments of the instrumented method to the annotated parameter. The annotated parameter must
      * be an array type. If the annotation indicates writability, the assigned array must have at least as many values as the
      * instrumented method or an {@link ArrayIndexOutOfBoundsException} is thrown.
+     *
+     * <b>Important</b>: Don't confuse this annotation with {@link net.bytebuddy.implementation.bind.annotation.AllArguments}
+     * annotation. This annotation should be used only in combination with {@link Advice} ASM visitor. For method
+     * delegation ({@link net.bytebuddy.implementation.MethodDelegation MethodDelegation.to(...)}) use alternative
+     * annotation from <code>net.bytebuddy.implementation.bind</code> package.
+     * </p>
      */
     @Documented
     @Retention(RetentionPolicy.RUNTIME)
@@ -11134,6 +11152,12 @@ public class Advice implements AsmVisitorWrapper.ForDeclaredMethods.MethodVisito
      * setting {@link ClassWriter#COMPUTE_MAXS}. This is however only relevant when writing to a non-static field.
      * </p>
      *
+     * <b>Important</b>: Don't confuse this annotation with {@link net.bytebuddy.implementation.bind.annotation.FieldValue}
+     * annotation. This annotation should be used only in combination with {@link Advice} ASM visitor. For method
+     * delegation ({@link net.bytebuddy.implementation.MethodDelegation MethodDelegation.to(...)}) use alternative
+     * annotation from <code>net.bytebuddy.implementation.bind</code> package.
+     * </p>
+     *
      * @see Advice
      * @see OnMethodEnter
      * @see OnMethodExit
@@ -11191,6 +11215,12 @@ public class Advice implements AsmVisitorWrapper.ForDeclaredMethods.MethodVisito
      * <p>
      * <b>Note</b>: A constant representing a {@link Method} or {@link Constructor} is not cached but is recreated for
      * every read.
+     * </p>
+     *
+     * <b>Important</b>: Don't confuse this annotation with {@link net.bytebuddy.implementation.bind.annotation.Origin}
+     * annotation. This annotation should be used only in combination with {@link Advice} ASM visitor. For method
+     * delegation ({@link net.bytebuddy.implementation.MethodDelegation MethodDelegation.to(...)}) use alternative
+     * annotation from <code>net.bytebuddy.implementation.bind</code> package.
      * </p>
      *
      * @see Advice
@@ -11322,6 +11352,12 @@ public class Advice implements AsmVisitorWrapper.ForDeclaredMethods.MethodVisito
      * Indicates that the annotated parameter should always return a default a boxed version of the instrumented methods return value
      * (i.e. {@code 0} for numeric values, {@code false} for {@code boolean} types and {@code null} for reference types). The annotated
      * parameter must be of type {@link Object} and cannot be assigned a value.
+     *
+     * <b>Important</b>: Don't confuse this annotation with {@link net.bytebuddy.implementation.bind.annotation.StubValue}
+     * annotation. This annotation should be used only in combination with {@link Advice} ASM visitor. For method
+     * delegation ({@link net.bytebuddy.implementation.MethodDelegation MethodDelegation.to(...)}) use alternative
+     * annotation from <code>net.bytebuddy.implementation.bind</code> package.
+     * </p>
      *
      * @see Advice
      * @see OnMethodEnter

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/bind/annotation/AllArguments.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/bind/annotation/AllArguments.java
@@ -46,6 +46,13 @@ import java.util.List;
  * use a {@link net.bytebuddy.implementation.bind.annotation.AllArguments.Assignment#SLACK} assignment
  * which simply skips non-assignable values instead.
  *
+ * <b>Important</b>: Don't confuse this annotation with {@link net.bytebuddy.asm.Advice.AllArguments} annotation. This annotation
+ * should be used only in combination with method delegation
+ * ({@link net.bytebuddy.implementation.MethodDelegation MethodDelegation.to(...)}).
+ * For {@link net.bytebuddy.asm.Advice} ASM visitor use alternative annotation from
+ * <code>net.bytebuddy.asm.Advice</code> package.
+ * </p>
+ *
  * @see net.bytebuddy.implementation.MethodDelegation
  * @see net.bytebuddy.implementation.bind.annotation.TargetMethodAnnotationDrivenBinder
  * @see net.bytebuddy.implementation.bind.annotation.RuntimeType

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/bind/annotation/Argument.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/bind/annotation/Argument.java
@@ -38,6 +38,13 @@ import java.lang.annotation.*;
  * annotation is excluded from the list of possible binding candidates to this particular source method. The same happens,
  * if the source method parameter at the specified index is not assignable to the annotated parameter.
  *
+ * <b>Important</b>: Don't confuse this annotation with {@link net.bytebuddy.asm.Advice.Argument} annotation. This annotation
+ * should be used only in combination with method delegation
+ * ({@link net.bytebuddy.implementation.MethodDelegation MethodDelegation.to(...)}).
+ * For {@link net.bytebuddy.asm.Advice} ASM visitor use alternative annotation from
+ * <code>net.bytebuddy.asm.Advice</code> package.
+ * </p>
+ *
  * @see net.bytebuddy.implementation.MethodDelegation
  * @see net.bytebuddy.implementation.bind.annotation.TargetMethodAnnotationDrivenBinder
  * @see net.bytebuddy.implementation.bind.annotation.RuntimeType

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/bind/annotation/FieldValue.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/bind/annotation/FieldValue.java
@@ -45,6 +45,13 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
  * to be an illegal candidate for binding.
  * </p>
  *
+ * <b>Important</b>: Don't confuse this annotation with {@link net.bytebuddy.asm.Advice.FieldValue} annotation. This annotation
+ * should be used only in combination with method delegation
+ * ({@link net.bytebuddy.implementation.MethodDelegation MethodDelegation.to(...)}).
+ * For {@link net.bytebuddy.asm.Advice} ASM visitor use alternative annotation from
+ * <code>net.bytebuddy.asm.Advice</code> package.
+ * </p>
+ *
  * @see net.bytebuddy.implementation.MethodDelegation
  * @see net.bytebuddy.implementation.bind.annotation.TargetMethodAnnotationDrivenBinder
  * @see net.bytebuddy.implementation.bind.annotation.RuntimeType

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/bind/annotation/Origin.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/bind/annotation/Origin.java
@@ -62,6 +62,13 @@ import java.lang.reflect.Method;
  * to the instrumented type or an {@link IllegalAccessError} will be thrown at runtime.
  * </p>
  *
+ * <b>Important</b>: Don't confuse this annotation with {@link net.bytebuddy.asm.Advice.Origin} annotation. This annotation
+ * should be used only in combination with method delegation
+ * ({@link net.bytebuddy.implementation.MethodDelegation MethodDelegation.to(...)}).
+ * For {@link net.bytebuddy.asm.Advice} ASM visitor use alternative annotation from
+ * <code>net.bytebuddy.asm.Advice</code> package.
+ * </p>
+ *
  * @see net.bytebuddy.implementation.MethodDelegation
  * @see net.bytebuddy.implementation.bind.annotation.TargetMethodAnnotationDrivenBinder
  */

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/bind/annotation/StubValue.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/bind/annotation/StubValue.java
@@ -36,6 +36,13 @@ import java.lang.annotation.*;
  * {@code null} if a method returns a reference type or {@code void} or a boxed primitive of the return type
  * representing the numeric value {@code 0}.
  *
+ * <b>Important</b>: Don't confuse this annotation with {@link net.bytebuddy.asm.Advice.StubValue} annotation. This
+ * annotation should be used only in combination with method delegation
+ * ({@link net.bytebuddy.implementation.MethodDelegation MethodDelegation.to(...)}).
+ * For {@link net.bytebuddy.asm.Advice} ASM visitor use alternative annotation from
+ * <code>net.bytebuddy.asm.Advice</code> package.
+ * </p>
+ *
  * @see net.bytebuddy.implementation.MethodDelegation
  * @see net.bytebuddy.implementation.bind.annotation.TargetMethodAnnotationDrivenBinder
  */

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/bind/annotation/This.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/bind/annotation/This.java
@@ -32,6 +32,13 @@ import java.lang.annotation.*;
  * the instrumented method is not static. Otherwise, the method with this parameter annotation will be excluded from
  * the list of possible binding candidates of the static source method.
  *
+ * <b>Important</b>: Don't confuse this annotation with {@link net.bytebuddy.asm.Advice.This} annotation. This annotation
+ * should be used only in combination with method delegation
+ * ({@link net.bytebuddy.implementation.MethodDelegation MethodDelegation.to(...)}).
+ * For {@link net.bytebuddy.asm.Advice} ASM visitor use alternative annotation from
+ * <code>net.bytebuddy.asm.Advice</code> package.
+ * </p>
+ *
  * @see net.bytebuddy.implementation.MethodDelegation
  * @see net.bytebuddy.implementation.bind.annotation.TargetMethodAnnotationDrivenBinder
  */


### PR DESCRIPTION
Added documentation to clarify the difference between annotations with same name but different usage. I tried my best.

I still think that there might be additional control in the builder - when using `MethodDelegation.to` there might be check that bound methods (i.e. the methods the created class delegates really to) contain only annotations from the correct package. Alternatively ASM visitor might verify that methods with annotations `OnMethodEnter` or `OnMethodExit` (are there additional "main" annotations?!) only accepts annotations from proper package on arguments of the same method.

But that's only my subjective opinion. Please ignore it, if it's not correct  - you have more deeper understanding of the code.