### PR TITLE
member substitution for newly defined elements and additional tests

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/asm/MemberSubstitution.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/asm/MemberSubstitution.java
@@ -1005,7 +1005,7 @@ public class MemberSubstitution implements AsmVisitorWrapper.ForDeclaredMethods.
                         } else if (parameters.get(0).isPrimitive() || parameters.get(0).isArray()) {
                             throw new IllegalStateException("Cannot access field on primitive or array type for " + target);
                         }
-                        TypeDefinition current = parameters.get(0);
+                        TypeDefinition current = instrumentedType;
                         do {
                             FieldList<?> fields = current.getDeclaredFields().filter(not(isStatic()).<FieldDescription>and(isVisibleTo(instrumentedType)).and(matcher));
                             if (fields.size() == 1) {
@@ -1226,7 +1226,7 @@ public class MemberSubstitution implements AsmVisitorWrapper.ForDeclaredMethods.
                         } else if (parameters.get(0).isPrimitive() || parameters.get(0).isArray()) {
                             throw new IllegalStateException("Cannot invoke method on primitive or array type for " + target);
                         }
-                        TypeDefinition typeDefinition = parameters.get(0);
+                        TypeDefinition typeDefinition = instrumentedType;
                         List<MethodDescription> candidates = CompoundList.<MethodDescription>of(methodGraphCompiler.compile(typeDefinition, instrumentedType)
                                 .listNodes()
                                 .asMethodList()


### PR DESCRIPTION
Fields and methods defined during an instrumentation aren't resolved by the matching resolver in member substitution.