### PR TITLE
Fix isGenerified to work with anonymous subclasses using the enclosing methods type parameter

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/description/TypeVariableSource.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/description/TypeVariableSource.java
@@ -88,6 +88,7 @@ public interface TypeVariableSource extends ModifierReviewable.OfAbstraction {
      * <ul>
      * <li>A type declares type variables or is an inner class of a type with a generic declaration.</li>
      * <li>A method declares at least one type variable.</li>
+     * <li>A type is an inner anonymous class of a method with a generic declaration</li>
      * </ul>
      *
      * @return {@code true} if this type code element has a generic declaration.

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/description/type/TypeDescription.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/description/type/TypeDescription.java
@@ -8060,7 +8060,11 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
                 return false;
             }
             TypeDescription declaringType = getDeclaringType();
-            return declaringType != null && declaringType.isGenerified();
+            if (declaringType != null && declaringType.isGenerified()) {
+                return true;
+            }
+            MethodDescription.InDefinedShape enclosingMethod = getEnclosingMethod();
+            return enclosingMethod != null && enclosingMethod.isGenerified();
         }
 
         /**

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/description/type/AbstractTypeDescriptionTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/description/type/AbstractTypeDescriptionTest.java
@@ -666,6 +666,7 @@ public abstract class AbstractTypeDescriptionTest extends AbstractTypeDescriptio
         assertThat(describe(GenericSample.Nested.class).isGenerified(), is(false));
         assertThat(describe(GenericSample.NestedInterface.class).isGenerified(), is(false));
         assertThat(describe(Object.class).isGenerified(), is(false));
+        assertThat(describe(getAnonymousGenericSample().getClass()).isGenerified(), is(true));
     }
 
     @Test
@@ -1032,6 +1033,12 @@ public abstract class AbstractTypeDescriptionTest extends AbstractTypeDescriptio
         interface NestedInterface {
             /* empty */
         }
+    }
+
+    private <T> GenericSample<T> getAnonymousGenericSample() {
+        return new GenericSample<T>() {
+            /* empty */
+        };
     }
 
     private static class Type$With$Dollar {


### PR DESCRIPTION
Fixes #1270 
I go into more detail what the bug is in the ticket, but I also added a test that reproduces it.
I am happy to make additional changes, also to the line in the documentation. I was not sure how to phrase it correctly.
Hope this helps!