### PR TITLE
Add CodeSizeEvaluator to remapped ASM commons

### DIFF
--- a/byte-buddy/pom.xml
+++ b/byte-buddy/pom.xml
@@ -276,6 +276,7 @@
                                             <includes>
                                                 <include>org/objectweb/asm/commons/AnnotationRemapper.**</include>
                                                 <include>org/objectweb/asm/commons/ClassRemapper.**</include>
+                                                <include>org/objectweb/asm/commons/CodeSizeEvaluator.**</include>
                                                 <include>org/objectweb/asm/commons/FieldRemapper.**</include>
                                                 <include>org/objectweb/asm/commons/MethodRemapper.**</include>
                                                 <include>org/objectweb/asm/commons/ModuleHashesAttribute.**</include>
@@ -368,6 +369,7 @@
                                             <includes>
                                                 <include>org/objectweb/asm/commons/AnnotationRemapper.**</include>
                                                 <include>org/objectweb/asm/commons/ClassRemapper.**</include>
+                                                <include>org/objectweb/asm/commons/CodeSizeEvaluator.**</include>
                                                 <include>org/objectweb/asm/commons/FieldRemapper.**</include>
                                                 <include>org/objectweb/asm/commons/MethodRemapper.**</include>
                                                 <include>org/objectweb/asm/commons/ModuleHashesAttribute.**</include>


### PR DESCRIPTION
When working on a ByteBuddy plugin (for Quarkus) to be used with the bytebuddy-maven-plugin, 
I encountered the need to use the `org.objectweb.asm.commons.CodeSizeEvaluator`, which has
not been included in the shaded jars.
This PR makes sure it's included