### PR TITLE
example fix for Working with unloaded classes section

### DIFF
--- a/partial/tutorial.partial.cn.html
+++ b/partial/tutorial.partial.cn.html
@@ -698,7 +698,8 @@ class MyApplication {
                 ClassFileLocator.ForClassLoader.ofSystemLoader())
       .defineField("qux", String.class) // we learn more about defining fields later
       .make()
-      .load(ClassLoader.getSystemClassLoader());
+      .load(ClassLoader.getSystemClassLoader(), ClassLoadingStrategy.Default.INJECTION)
+      .getLoaded();
     assertThat(bar.getDeclaredField("qux"), notNullValue());
   }
 }

--- a/partial/tutorial.partial.html
+++ b/partial/tutorial.partial.html
@@ -835,7 +835,8 @@ class MyApplication {
                 ClassFileLocator.ForClassLoader.ofSystemLoader())
       .defineField("qux", String.class) // we learn more about defining fields later
       .make()
-      .load(ClassLoader.getSystemClassLoader());
+      .load(ClassLoader.getSystemClassLoader(), ClassLoadingStrategy.Default.INJECTION)
+      .getLoaded();
     assertThat(bar.getDeclaredField("qux"), notNullValue());
   }
 }


### PR DESCRIPTION
Example was not working before because of type mismatch of `bar` variable and the result of method chain (the absence of `getLoaded` method). 
Also in case `Foo` class is in the same module `ClassLoadingStrategy.Default.WRAPPER` loads it first so no class update happens. So i suggest to use in example `ClassLoadingStrategy.Default.INJECTION` instead