### PR TITLE
Using explicit ProtectionDomain in dynamically loaded classes

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/dynamic/loading/ClassInjector.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/dynamic/loading/ClassInjector.java
@@ -1189,7 +1189,7 @@ public interface ClassInjector {
                                 .noNestMate()
                                 .visit(new MemberRemoval().stripInvokables(any()))
                                 .make()
-                                .load(AccessibleObject.class.getClassLoader(), ClassLoadingStrategy.Default.WRAPPER)
+                                .load(AccessibleObject.class.getClassLoader(), ClassLoadingStrategy.Default.WRAPPER.with(AccessibleObject.class.getProtectionDomain()))
                                 .getLoaded()
                                 .getDeclaredField("override");
                     }

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/dynamic/loading/ClassInjector.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/dynamic/loading/ClassInjector.java
@@ -1952,7 +1952,7 @@ public interface ClassInjector {
                                             .noNestMate()
                                             .visit(new MemberRemoval().stripInvokables(any()))
                                             .make()
-                                            .load(AccessibleObject.class.getClassLoader(), ClassLoadingStrategy.Default.WRAPPER)
+                                            .load(AccessibleObject.class.getClassLoader(), ClassLoadingStrategy.Default.WRAPPER.with(AccessibleObject.class.getProtectionDomain()))
                                             .getLoaded()
                                             .getDeclaredField("override");
                                 }


### PR DESCRIPTION
Fixes the errors described in https://github.com/elastic/apm-agent-java/pull/2539 