### PR TITLE
Fix .gitignore rule for Gradle build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,10 +20,8 @@ maven-checksum-extension.jar
 
 # Gradle
 .gradle/
-byte-buddy-gradle-plugin/build/
-byte-buddy-gradle-plugin/**/build/
-byte-buddy-gradle-plugin/buildSrc/build/
-byte-buddy-gradle-plugin/gradle/build/
+build/
+!**/src/**/build/
 gradle-*-bin.zip
 gradle-wrapper.jar
 


### PR DESCRIPTION
Fixes #1380

With the previous rules, some source files in the net.bytebuddy.build package were ignored in some subprojects.

See also: https://github.com/gradle/gradle/issues/18737