### PR TITLE
Add public addURL to BOOT_LOADER_PROXY

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/dynamic/ClassFileLocator.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/dynamic/ClassFileLocator.java
@@ -476,7 +476,29 @@ public interface ClassFileLocator extends Closeable {
              * {@inheritDoc}
              */
             public ClassLoader run() {
-                return new URLClassLoader(new URL[0], ClassLoadingStrategy.BOOTSTRAP_LOADER);
+                return new BootLoaderProxy(new URL[0], ClassLoadingStrategy.BOOTSTRAP_LOADER);
+            }
+
+            /**
+             * A URLClassLoader which exposes addURL to be used as a Bootloader Proxy.
+             */
+            class BootLoaderProxy extends URLClassLoader {
+                /**
+                  * Constructs a new BootLoaderProxy for the given URLs and parent ClassLoader.
+                  * @param      urls the URLs from which to load classes and resources
+                  * @param      parent the parent class loader for delegation
+                  */
+                BootLoaderProxy(URL[] urls, ClassLoader parent) {
+                    super(urls, parent);
+                }
+
+                /**
+                 * {@inheritDoc}
+                 */
+                @Override
+                public void addURL(URL url) {
+                    super.addURL(url);
+                }
             }
         }
 


### PR DESCRIPTION
We own an Amazon open-source project which utilizes ByteBuddy, and this PR for ByteBuddy solves an obstacle we have encountered in supporting Java 17. Our project: [https://github.com/awslabs/disco](https://github.com/awslabs/disco)

Disco is an open source event-driven toolkit. Disco provides a framework for plugins which may use features offered by the toolkit, the primary of which being Context Propagation (across threads and services) and Events. Disco vends a Java Agent which services use, where plugins are loaded by the Disco Java Agent and may themselves be thought of as agents. Installables - components of some plugins - utilize ByteBuddy to perform instrumentations (for example, a plugin may instrument Apache to propagate context through service calls.) Installable Interface: [https://github.com/awslabs/disco/blob/master/disco-java-agent/disco-java-agent-plugin-api/src/main/java/software/amazon/disco/agent/interception/Installable.java#L35](https://github.com/awslabs/disco/blob/master/disco-java-agent/disco-java-agent-plugin-api/src/main/java/software/amazon/disco/agent/interception/Installable.java#L35)

Some plugins have a requirement to exist on the bootstrap classloader and may be injected to it at runtime during the PluginDiscovery phase of the Disco Java Agent. [https://github.com/awslabs/disco/blob/master/disco-java-agent/disco-java-agent-core/src/main/java/software/amazon/disco/agent/plugin/PluginDiscovery.java#L311](https://github.com/awslabs/disco/blob/master/disco-java-agent/disco-java-agent-core/src/main/java/software/amazon/disco/agent/plugin/PluginDiscovery.java#L311)

Since these plugins can define installables which utilize ByteBuddy to perform instrumentations, they commonly define classes which need to be loaded as resources by ByteBuddy (e.g. Advices). Because the bootstrap classloader does not support resource loading, just classloading, we rely on ByteBuddy’s BOOT_LOADER_PROXY. When bootstrap plugins are loaded during runtime, we reflectively call addURL on ByteBuddy’s BOOT_LOADER_PROXY, since ByteBuddy will check here by-default for performing bootstrap resource loading. [https://github.com/awslabs/disco/blob/master/disco-java-agent/disco-java-agent-inject-api/src/main/java/software/amazon/disco/agent/inject/Injector.java#L144](https://github.com/awslabs/disco/blob/master/disco-java-agent/disco-java-agent-inject-api/src/main/java/software/amazon/disco/agent/inject/Injector.java#L144)

This saves plugin developers the undifferentiated effort of utilizing a ClassFileLocator in their installables and needing to be aware of what mechanism the Disco Java Agent is using to load them. By performing this work when loading the plugins, they can be injected onto the bootstrap classloader at runtime by Disco Java Agent, and interface with the AgentBuilders that we vend to them in the installable interface without themselves carrying specific logic around how they were loaded.

However, with JDK 17, this reflective access is prevented, as addURL is protected in URLClassLoader and access modifiers are more strongly enforced. The change here would enable us to continue to ensure that these bootstrap plugins can be resource-loaded with the AgentBuilders we supply to them by-default without needing all plugin developers to take on work to update their usages of ByteBuddy to use a ClassFileLocator which matches how we have loaded their plugins.
