### PR TITLE
Remove updateReleaseInfo parameter.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -350,9 +350,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>${version.plugin.deploy}</version>
-                    <configuration>
-                        <updateReleaseInfo>true</updateReleaseInfo>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
The updateReleaseInfo parameter has been removed in v3.0.0
see: https://blogs.apache.org/maven/entry/apache-maven-deploy-plugin-version 