### PR TITLE
Override close() in DynamicType to not throw any Exceptions.

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/dynamic/DynamicType.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/dynamic/DynamicType.java
@@ -193,6 +193,12 @@ public interface DynamicType extends ClassFileLocator {
     File toJar(File file, Manifest manifest) throws IOException;
 
     /**
+     * Releases any resources this instance may hold.
+     */
+    @Override
+    void close();
+
+    /**
      * A builder for creating a dynamic type.
      *
      * @param <T> A loaded type that the built type is guaranteed to be a subclass of.


### PR DESCRIPTION
This simplifies usage with try-with-resources. Currently users are forced to write something like this:
```java
final var unloadedClass = myClassBuilder.make();
try {
  return unloadedClass
    .load(...)
    .getLoaded();
} finally {
  try {
    unloadedClass.close();
  } catch (IOException e) {
    log.warn("OMG! OMG! PANIC! WHAT DO WE DO NOW??", e);
  }
}
```
while after the change it may be simply like this:
```java
try (
  final var unloadedClass = myClassBuilder.make()
) {
  return unloadedClass
    .load(...)
    .getLoaded();
}
```
This also follows the recommendation from  [AutoCloseable.close() javadoc](https://docs.oracle.com/javase/8/docs/api/java/lang/AutoCloseable.html#close--) which says:
> implementers are strongly encouraged to declare concrete implementations of the close method to throw more specific exceptions, or to throw no exception at all if the close operation cannot fail. 

(implementer here is `Default` which actually does have `close()` without any exception, but users usually interact with `DynamicType`/`Unloaded` which inherit unnecessary exception from `Closeable`)