### PR TITLE
Fix reading bytecode version for java1

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/ClassFileVersion.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/ClassFileVersion.java
@@ -402,7 +402,7 @@ public class ClassFileVersion implements Comparable<ClassFileVersion>, Serializa
         if (binaryRepresentation.length < 7) {
             throw new IllegalArgumentException("Supplied byte array is too short to be a class file with " + binaryRepresentation.length + " byte");
         }
-        return ofMinorMajor(binaryRepresentation[6] << 8 | binaryRepresentation[7] & 0xFF);
+        return ofMinorMajor(binaryRepresentation[5] << 16 | binaryRepresentation[7] & 0xFF);
     }
 
     /**

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/ClassFileVersionTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/ClassFileVersionTest.java
@@ -77,6 +77,17 @@ public class ClassFileVersionTest {
         ClassFileVersion.ofClassFile(new byte[0]);
     }
 
+    @Test
+    public void testClassFileVersion() {
+        for (int i = 1; i < ClassFileVersion.latest().getJavaVersion(); i++) {
+            byte major = (byte) (44 + i);
+            byte minor = (byte) (i == 1 ? 3 : 0);
+
+            ClassFileVersion expected = ClassFileVersion.ofJavaVersion(i);
+            assertThat(ClassFileVersion.ofClassFile(new byte[]{0, 0, 0, 0, 0, minor, 0, major}), is(expected));
+        }
+    }
+
     private static class Foo {
         /* empty */
     }


### PR DESCRIPTION
The Java class file format ([doc](https://jcp.org/aboutJava/communityprocess/maintenance/jsr924/JVMS-SE5.0-Ch4-ClassFile.pdf)) stores the bytecode version in the bytes 4 to 8 just after the famous `0xCAFEBABE` magic value.
In practice, the minor version hasn't been used since Java1, and both minor and major can be read as single bytes.

When reading the version of an existing class compiled for Java 1, the minor version (3) is read at the wrong offset and is thus ignored, however the major version (45) is properly read, which makes it as if we were attempting to read a class that was compiled for Java 1.0 ([doc](https://javaalmanac.io/bytecode/versions/)), which is not covered by ASM as there isn't any `Opcodes.V1_0`.

This PR fixes the bug in version reading and adds a test to cover it.