### PR TITLE
Fix flaky

### DIFF
--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
@@ -68,12 +68,6 @@ public class AbstractMethodCallProxyTest {
                 }
             }
         }
-        Comparator<Class<?>> typeComparator = new Comparator<Class<?>>() {
-            @Override
-            public int compare(Class<?> a, Class<?> b) {
-                return a.getSimpleName().compareTo(b.getSimpleName());
-            }
-        };
         ArrayList<Class<?>> filteredFields = new ArrayList<Class<?>>();
         for (Field field : auxiliaryType.getDeclaredFields()) {
             if (field.getType() != proxyTarget) {
@@ -83,6 +77,12 @@ public class AbstractMethodCallProxyTest {
         Collections.sort(filteredFields, typeComparator);
         ArrayList<Class<?>> parameterTypes = new ArrayList<Class<?>>(Arrays.asList(proxyTarget.getDeclaredMethods()[0].getParameterTypes()));
         Collections.sort(parameterTypes, typeComparator);
+                Comparator<Class<?>> typeComparator = new Comparator<Class<?>>() {
+            @Override
+            public int compare(Class<?> a, Class<?> b) {
+                return a.getSimpleName().compareTo(b.getSimpleName());
+            }
+        };
         assertThat(filteredFields, CoreMatchers.is(parameterTypes));
         return auxiliaryType;
     }

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
@@ -56,6 +56,7 @@ public class AbstractMethodCallProxyTest {
         assertThat(auxiliaryType.getDeclaredMethods().length, is(2));
         assertThat(auxiliaryType.getDeclaredFields().length, is(proxyMethod.getParameters().size() + (proxyMethod.isStatic() ? 0 : 1)));
         int fieldIndex = 0;
+        // simple comment
         if (!proxyMethod.isStatic()) {
             assertThat(auxiliaryType.getDeclaredFields()[fieldIndex++].getType(), CoreMatchers.<Class<?>>is(proxyTarget));
         }

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
@@ -83,7 +83,6 @@ public class AbstractMethodCallProxyTest {
         Collections.sort(filteredFields, typeComparator);
         ArrayList<Class<?>> parameterTypes = new ArrayList<Class<?>>(Arrays.asList(proxyTarget.getDeclaredMethods()[0].getParameterTypes()));
         Collections.sort(parameterTypes, typeComparator);
-       
         assertThat(filteredFields, CoreMatchers.is(parameterTypes));
         return auxiliaryType;
     }

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
@@ -56,7 +56,6 @@ public class AbstractMethodCallProxyTest {
         assertThat(auxiliaryType.getDeclaredConstructors().length, is(1));
         assertThat(auxiliaryType.getDeclaredMethods().length, is(2));
         assertThat(auxiliaryType.getDeclaredFields().length, is(proxyMethod.getParameters().size() + (proxyMethod.isStatic() ? 0 : 1)));       
-        Class<?>[] parameterTypes = proxyTarget.getDeclaredMethods()[0].getParameterTypes();
         Field targetField = null;
         for (Field field : auxiliaryType.getDeclaredFields()) {
             if (field.getType() == proxyTarget) {
@@ -67,7 +66,7 @@ public class AbstractMethodCallProxyTest {
         if (!proxyMethod.isStatic() && targetField != null) {
             assertThat(targetField.getType(), CoreMatchers.<Class<?>>is(proxyTarget));
         }
-        for (Class<?> parameterType : parameterTypes){
+        for (Class<?> parameterType : proxyTarget.getDeclaredMethods()[0].getParameterTypes()){
             Class<?> found = null;
             for (Field field : auxiliaryType.getDeclaredFields()) {
                 if (field.getType().equals(parameterType)) {

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
@@ -74,19 +74,28 @@ public class AbstractMethodCallProxyTest {
         		  filteredFields.add(field.getType());
               }  
         }
-        Collections.sort(filteredFields, new Comparator<Class<?>>() {
+        Comparator<Class<?>> classComparator = new Comparator<Class<?>>() {
             @Override
             public int compare(Class<?> class1, Class<?> class2) {
                 return class1.getSimpleName().compareTo(class2.getSimpleName());
             }
-        });
+        };
         ArrayList<Class<?>> parameterTypes = new ArrayList<Class<?>>(Arrays.asList(proxyTarget.getDeclaredMethods()[0].getParameterTypes()));
-        Collections.sort(parameterTypes, new Comparator<Class<?>>() {
-            @Override
-            public int compare(Class<?> class1, Class<?> class2) {
-                return class1.getSimpleName().compareTo(class2.getSimpleName());
-            }
-        });
+        Collection.sort(filteredFields,classComparator);
+        Collection.sort(parameterTypes,classComparator);
+        // Collections.sort(filteredFields, new Comparator<Class<?>>() {
+        //     @Override
+        //     public int compare(Class<?> class1, Class<?> class2) {
+        //         return class1.getSimpleName().compareTo(class2.getSimpleName());
+        //     }
+        // });
+       
+        // Collections.sort(parameterTypes, new Comparator<Class<?>>() {
+        //     @Override
+        //     public int compare(Class<?> class1, Class<?> class2) {
+        //         return class1.getSimpleName().compareTo(class2.getSimpleName());
+        //     }
+        // });
         assertThat(filteredFields, CoreMatchers.is(parameterTypes));
         return auxiliaryType;
     }

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
@@ -59,7 +59,7 @@ public class AbstractMethodCallProxyTest {
         assertThat(Runnable.class.isAssignableFrom(auxiliaryType), is(true));
         assertThat(auxiliaryType.getDeclaredConstructors().length, is(1));
         assertThat(auxiliaryType.getDeclaredMethods().length, is(2));
-        assertThat(auxiliaryType.getDeclaredFields().length, is(proxyMethod.getParameters().size() + (proxyMethod.isStatic() ? 0 : 1)));       
+        assertThat(auxiliaryType.getDeclaredFields().length, is(proxyMethod.getParameters().size() + (proxyMethod.isStatic() ? 0 : 1)));
         if(!proxyMethod.isStatic()){
             for (Field field : auxiliaryType.getDeclaredFields()){
                 if (field.getType() == proxyTarget){

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
@@ -15,13 +15,14 @@ import org.mockito.junit.MockitoJUnit;
 import org.objectweb.asm.Opcodes;
 
 import java.util.concurrent.Callable;
+import java.lang.reflect.Field;
 
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.*;
-import java.lang.reflect.Field;
+
 
 public class AbstractMethodCallProxyTest {
 
@@ -67,18 +68,15 @@ public class AbstractMethodCallProxyTest {
             }
         }
         if (!proxyMethod.isStatic()) {
-        	Field field = fields[proxyTargetPosition];
-            assertThat(field.getType(), CoreMatchers.<Class<?>>is(proxyTarget));
+            assertThat(fields[proxyTargetPosition].getType(), CoreMatchers.<Class<?>>is(proxyTarget));
         }
         for (int i = 0; i < parameterTypes.length; i++) {
-            Field field = fields[i];
-            Class<?> fieldType = field.getType();
+            Class<?> fieldType = fields[i].getType();
             Class<?> parameterType = parameterTypes[i];
             found =null;
             for (Field field1 : fields) {
-                Class<?> fieldType1 = field1.getType();
-                if (fieldType1.equals(parameterType)) {
-                    found = fieldType1;
+                if (field1.getType().equals(parameterType)) {
+                    found = field1.getType();
                     break;
                 }
             }

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
@@ -88,7 +88,6 @@ public class AbstractMethodCallProxyTest {
                 return class1.getSimpleName().compareTo(class2.getSimpleName());
             }
         });
-        //
         assertThat(filteredFields, CoreMatchers.is(parameterTypes));
         return auxiliaryType;
     }

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
@@ -17,9 +17,9 @@ import org.objectweb.asm.Opcodes;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.concurrent.Callable;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.concurrent.Callable;
 
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.not;

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
@@ -23,7 +23,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.*;
 
-
 public class AbstractMethodCallProxyTest {
 
     protected static final String FOO = "foo";

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
@@ -55,8 +55,7 @@ public class AbstractMethodCallProxyTest {
         assertThat(Runnable.class.isAssignableFrom(auxiliaryType), is(true));
         assertThat(auxiliaryType.getDeclaredConstructors().length, is(1));
         assertThat(auxiliaryType.getDeclaredMethods().length, is(2));
-        assertThat(auxiliaryType.getDeclaredFields().length, is(proxyMethod.getParameters().size() + (proxyMethod.isStatic() ? 0 : 1)));
-             
+        assertThat(auxiliaryType.getDeclaredFields().length, is(proxyMethod.getParameters().size() + (proxyMethod.isStatic() ? 0 : 1)));       
         Class<?>[] parameterTypes = proxyTarget.getDeclaredMethods()[0].getParameterTypes();
         Field targetField = null;
         for (Field field : auxiliaryType.getDeclaredFields()) {
@@ -68,7 +67,7 @@ public class AbstractMethodCallProxyTest {
         if (!proxyMethod.isStatic() && targetField != null) {
             assertThat(targetField.getType(), CoreMatchers.<Class<?>>is(proxyTarget));
         }
-        for (Class<?> parameterType = parameterTypes){
+        for (Class<?> parameterType : parameterTypes){
             Class<?> found = null;
             for (Field field : auxiliaryType.getDeclaredFields()) {
                 if (field.getType().equals(parameterType)) {

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
@@ -60,19 +60,13 @@ public class AbstractMethodCallProxyTest {
         assertThat(auxiliaryType.getDeclaredConstructors().length, is(1));
         assertThat(auxiliaryType.getDeclaredMethods().length, is(2));
         assertThat(auxiliaryType.getDeclaredFields().length, is(proxyMethod.getParameters().size() + (proxyMethod.isStatic() ? 0 : 1)));
-        if(!proxyMethod.isStatic()){
-            for (Field field : auxiliaryType.getDeclaredFields()){
-                if (field.getType() == proxyTarget){
-                	assertThat(field.getType(), CoreMatchers.<Class<?>>is(proxyTarget));
+        if (!proxyMethod.isStatic()) {
+            for (Field field : auxiliaryType.getDeclaredFields()) {
+                if (field.getType() == proxyTarget) {
+                    assertThat(field.getType(), CoreMatchers.<Class<?>>is(proxyTarget));
                     break;
-                }  
+                }
             }
-        }
-        ArrayList<Class<?>> filteredFields = new ArrayList<Class<?>>();
-        for(Field field : auxiliaryType.getDeclaredFields()) {
-        	  if (field.getType() != proxyTarget){
-        		  filteredFields.add(field.getType());
-              }  
         }
         Comparator<Class<?>> classComparator = new Comparator<Class<?>>() {
             @Override
@@ -80,22 +74,15 @@ public class AbstractMethodCallProxyTest {
                 return class1.getSimpleName().compareTo(class2.getSimpleName());
             }
         };
+        ArrayList<Class<?>> filteredFields = new ArrayList<Class<?>>();
+        for (Field field : auxiliaryType.getDeclaredFields()) {
+            if (field.getType() != proxyTarget) {
+                filteredFields.add(field.getType());
+            }
+        }
         ArrayList<Class<?>> parameterTypes = new ArrayList<Class<?>>(Arrays.asList(proxyTarget.getDeclaredMethods()[0].getParameterTypes()));
-        Collections.sort(filteredFields,classComparator);
-        Collections.sort(parameterTypes,classComparator);
-        // Collections.sort(filteredFields, new Comparator<Class<?>>() {
-        //     @Override
-        //     public int compare(Class<?> class1, Class<?> class2) {
-        //         return class1.getSimpleName().compareTo(class2.getSimpleName());
-        //     }
-        // });
-       
-        // Collections.sort(parameterTypes, new Comparator<Class<?>>() {
-        //     @Override
-        //     public int compare(Class<?> class1, Class<?> class2) {
-        //         return class1.getSimpleName().compareTo(class2.getSimpleName());
-        //     }
-        // });
+        Collections.sort(filteredFields, classComparator);
+        Collections.sort(parameterTypes, classComparator);
         assertThat(filteredFields, CoreMatchers.is(parameterTypes));
         return auxiliaryType;
     }

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
@@ -74,9 +74,9 @@ public class AbstractMethodCallProxyTest {
         for (int i = 0; i < parameterTypes.length; i++){
             Class<?> parameterType = parameterTypes[i];
             found =null;
-            for (Field field1 : fields) {
-                if (field1.getType().equals(parameterType)) {
-                    found = field1.getType();
+            for (Field field : fields) {
+                if (field.getType().equals(parameterType)) {
+                    found = field.getType();
                     break;
                 }
             }

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
@@ -74,15 +74,16 @@ public class AbstractMethodCallProxyTest {
                 filteredFields.add(field.getType());
             }
         }
-        Collections.sort(filteredFields, typeComparator);
-        ArrayList<Class<?>> parameterTypes = new ArrayList<Class<?>>(Arrays.asList(proxyTarget.getDeclaredMethods()[0].getParameterTypes()));
-        Collections.sort(parameterTypes, typeComparator);
-                Comparator<Class<?>> typeComparator = new Comparator<Class<?>>() {
+        Comparator<Class<?>> typeComparator = new Comparator<Class<?>>() {
             @Override
             public int compare(Class<?> a, Class<?> b) {
                 return a.getSimpleName().compareTo(b.getSimpleName());
             }
         };
+        Collections.sort(filteredFields, typeComparator);
+        ArrayList<Class<?>> parameterTypes = new ArrayList<Class<?>>(Arrays.asList(proxyTarget.getDeclaredMethods()[0].getParameterTypes()));
+        Collections.sort(parameterTypes, typeComparator);
+       
         assertThat(filteredFields, CoreMatchers.is(parameterTypes));
         return auxiliaryType;
     }

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
@@ -88,6 +88,7 @@ public class AbstractMethodCallProxyTest {
                 return class1.getSimpleName().compareTo(class2.getSimpleName());
             }
         });
+        //
         assertThat(filteredFields, CoreMatchers.is(parameterTypes));
         return auxiliaryType;
     }

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
@@ -1,7 +1,6 @@
 package net.bytebuddy.implementation.auxiliary;
 
 import net.bytebuddy.ClassFileVersion;
-import java.lang.reflect.Parameter;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.DynamicType;
@@ -88,7 +87,6 @@ public class AbstractMethodCallProxyTest {
                 return class1.getSimpleName().compareTo(class2.getSimpleName());
             }
         });
-        //
         assertThat(filteredFields, CoreMatchers.is(parameterTypes));
         return auxiliaryType;
     }

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
@@ -14,8 +14,9 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.objectweb.asm.Opcodes;
 
-import java.util.concurrent.Callable;
 import java.lang.reflect.Field;
+import java.util.concurrent.Callable;
+
 
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.not;

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
@@ -68,7 +68,7 @@ public class AbstractMethodCallProxyTest {
                 }
             }
         }
-        Comparator<Class<?>> classComparator = new Comparator<Class<?>>() {
+        Comparator<Class<?>> typeComparator = new Comparator<Class<?>>() {
             @Override
             public int compare(Class<?> class1, Class<?> class2) {
                 return class1.getSimpleName().compareTo(class2.getSimpleName());
@@ -81,8 +81,8 @@ public class AbstractMethodCallProxyTest {
             }
         }
         ArrayList<Class<?>> parameterTypes = new ArrayList<Class<?>>(Arrays.asList(proxyTarget.getDeclaredMethods()[0].getParameterTypes()));
-        Collections.sort(filteredFields, classComparator);
-        Collections.sort(parameterTypes, classComparator);
+        Collections.sort(filteredFields, typeComparator);
+        Collections.sort(parameterTypes, typeComparator);
         assertThat(filteredFields, CoreMatchers.is(parameterTypes));
         return auxiliaryType;
     }

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
@@ -81,8 +81,8 @@ public class AbstractMethodCallProxyTest {
             }
         };
         ArrayList<Class<?>> parameterTypes = new ArrayList<Class<?>>(Arrays.asList(proxyTarget.getDeclaredMethods()[0].getParameterTypes()));
-        Collection.sort(filteredFields,classComparator);
-        Collection.sort(parameterTypes,classComparator);
+        Collections.sort(filteredFields,classComparator);
+        Collections.sort(parameterTypes,classComparator);
         // Collections.sort(filteredFields, new Comparator<Class<?>>() {
         //     @Override
         //     public int compare(Class<?> class1, Class<?> class2) {

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
@@ -70,8 +70,8 @@ public class AbstractMethodCallProxyTest {
         }
         Comparator<Class<?>> typeComparator = new Comparator<Class<?>>() {
             @Override
-            public int compare(Class<?> class1, Class<?> class2) {
-                return class1.getSimpleName().compareTo(class2.getSimpleName());
+            public int compare(Class<?> a, Class<?> b) {
+                return a.getSimpleName().compareTo(b.getSimpleName());
             }
         };
         ArrayList<Class<?>> filteredFields = new ArrayList<Class<?>>();
@@ -80,8 +80,8 @@ public class AbstractMethodCallProxyTest {
                 filteredFields.add(field.getType());
             }
         }
-        ArrayList<Class<?>> parameterTypes = new ArrayList<Class<?>>(Arrays.asList(proxyTarget.getDeclaredMethods()[0].getParameterTypes()));
         Collections.sort(filteredFields, typeComparator);
+        ArrayList<Class<?>> parameterTypes = new ArrayList<Class<?>>(Arrays.asList(proxyTarget.getDeclaredMethods()[0].getParameterTypes()));
         Collections.sort(parameterTypes, typeComparator);
         assertThat(filteredFields, CoreMatchers.is(parameterTypes));
         return auxiliaryType;

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
@@ -71,8 +71,7 @@ public class AbstractMethodCallProxyTest {
         if (!proxyMethod.isStatic()) {
             assertThat(fields[proxyTargetPosition].getType(), CoreMatchers.<Class<?>>is(proxyTarget));
         }
-        for (int i = 0; i < parameterTypes.length; i++) {
-            Class<?> fieldType = fields[i].getType();
+        for (int i = 0; i < parameterTypes.length; i++){
             Class<?> parameterType = parameterTypes[i];
             found =null;
             for (Field field1 : fields) {

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
@@ -21,6 +21,7 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.*;
+import java.lang.reflect.Field;
 
 public class AbstractMethodCallProxyTest {
 
@@ -55,13 +56,33 @@ public class AbstractMethodCallProxyTest {
         assertThat(auxiliaryType.getDeclaredConstructors().length, is(1));
         assertThat(auxiliaryType.getDeclaredMethods().length, is(2));
         assertThat(auxiliaryType.getDeclaredFields().length, is(proxyMethod.getParameters().size() + (proxyMethod.isStatic() ? 0 : 1)));
-        int fieldIndex = 0;
-        // simple comment
-        if (!proxyMethod.isStatic()) {
-            assertThat(auxiliaryType.getDeclaredFields()[fieldIndex++].getType(), CoreMatchers.<Class<?>>is(proxyTarget));
+        Field[] fields = auxiliaryType.getDeclaredFields();     
+        Class<?>[] parameterTypes = proxyTarget.getDeclaredMethods()[0].getParameterTypes();
+        Class<?> found ;
+        int proxyTargetPosition = -1;
+        for (int i = 0; i < fields.length; i++) {
+            if (fields[i].getType() == proxyTarget) {
+                proxyTargetPosition = i;
+                break;
+            }
         }
-        for (Class<?> parameterType : proxyTarget.getDeclaredMethods()[0].getParameterTypes()) {
-            assertThat(auxiliaryType.getDeclaredFields()[fieldIndex++].getType(), CoreMatchers.<Class<?>>is(parameterType));
+        if (!proxyMethod.isStatic()) {
+        	Field field = fields[proxyTargetPosition];
+            assertThat(field.getType(), CoreMatchers.<Class<?>>is(proxyTarget));
+        }
+        for (int i = 0; i < parameterTypes.length; i++) {
+            Field field = fields[i];
+            Class<?> fieldType = field.getType();
+            Class<?> parameterType = parameterTypes[i];
+            found =null;
+            for (Field field1 : fields) {
+                Class<?> fieldType1 = field1.getType();
+                if (fieldType1.equals(parameterType)) {
+                    found = fieldType1;
+                    break;
+                }
+            }
+            assertThat(found, CoreMatchers.<Class<?>>is(parameterType));
         }
         return auxiliaryType;
     }

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
@@ -69,7 +69,7 @@ public class AbstractMethodCallProxyTest {
                 }  
             }
         }
-        ArrayList<Class<?>> filteredFields = new ArrayList<>();
+        ArrayList<Class<?>> filteredFields = new ArrayList<Class<?>>();
         for(Field field : auxiliaryType.getDeclaredFields()) {
         	  if (field.getType() != proxyTarget){
         		  filteredFields.add(field.getType());
@@ -88,7 +88,6 @@ public class AbstractMethodCallProxyTest {
                 return class1.getSimpleName().compareTo(class2.getSimpleName());
             }
         });
-        //
         assertThat(filteredFields, CoreMatchers.is(parameterTypes));
         return auxiliaryType;
     }

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/auxiliary/AbstractMethodCallProxyTest.java
@@ -17,7 +17,6 @@ import org.objectweb.asm.Opcodes;
 import java.lang.reflect.Field;
 import java.util.concurrent.Callable;
 
-
 import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 import static org.hamcrest.CoreMatchers.is;
@@ -58,23 +57,21 @@ public class AbstractMethodCallProxyTest {
         assertThat(auxiliaryType.getDeclaredConstructors().length, is(1));
         assertThat(auxiliaryType.getDeclaredMethods().length, is(2));
         assertThat(auxiliaryType.getDeclaredFields().length, is(proxyMethod.getParameters().size() + (proxyMethod.isStatic() ? 0 : 1)));
-        Field[] fields = auxiliaryType.getDeclaredFields();     
+             
         Class<?>[] parameterTypes = proxyTarget.getDeclaredMethods()[0].getParameterTypes();
-        Class<?> found ;
-        int proxyTargetPosition = -1;
-        for (int i = 0; i < fields.length; i++) {
-            if (fields[i].getType() == proxyTarget) {
-                proxyTargetPosition = i;
+        Field targetField = null;
+        for (Field field : auxiliaryType.getDeclaredFields()) {
+            if (field.getType() == proxyTarget) {
+                targetField = field;
                 break;
             }
         }
-        if (!proxyMethod.isStatic()) {
-            assertThat(fields[proxyTargetPosition].getType(), CoreMatchers.<Class<?>>is(proxyTarget));
+        if (!proxyMethod.isStatic() && targetField != null) {
+            assertThat(targetField.getType(), CoreMatchers.<Class<?>>is(proxyTarget));
         }
-        for (int i = 0; i < parameterTypes.length; i++){
-            Class<?> parameterType = parameterTypes[i];
-            found =null;
-            for (Field field : fields) {
+        for (Class<?> parameterType = parameterTypes){
+            Class<?> found = null;
+            for (Field field : auxiliaryType.getDeclaredFields()) {
                 if (field.getType().equals(parameterType)) {
                     found = field.getType();
                     break;


### PR DESCRIPTION
**What is the purpose of this PR**

- This PR fixes the error resulting from the flaky test: `net.bytebuddy.implementation.auxiliary.MethodCallProxyTest.testMultipleParameterMethod`.

- The mentioned tests may fail or pass without changes made to the source code when it is run in different JVMs due to `getDeclaredFields` non-deterministic order.

**Why the tests fail**

- This test fails because `MethodCallProxyTest` calls `AbstractMethodCallProxyTest`, and there are 2 assertions that fail which use `getDeclaredFields` to assert the field types. 
- As per the Java documentation, the `getDeclaredFields` method returns the array of fields, and the elements in the returned array are not sorted and are not in any particular order. So, the test fails as the given order can be different from the expected order. This has been the case since `Java 1.1` version.

**Reproduce the test failure**

- Run the tests with NonDex maven plugin. The commands to recreate the flaky test failures are:

- `mvn -pl cli edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=net.bytebuddy.implementation.auxiliary.MethodCallProxyTest#testMultipleParameterMethod`


- Fixing the flaky test now may prevent flaky test failures in future Java versions.

**Expected results**

- Both tests should run successfully when run with `NonDex`.

**Actual Result**

- We get the following failure for the test:`[INFO] Running net.bytebuddy.implementation.auxiliary.MethodCallProxyTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.423 s <<< FAILURE! - in net.bytebuddy.implementation.auxiliary.MethodCallProxyTest
[ERROR]testMultipleParameterMethod(net.bytebuddy.implementation.auxiliary.MethodCallProxyTest) Time elapsed: 0.417 s <<< FAILURE! java.lang.AssertionError`


**Fix**

- For the first assertion failure, we obtain `proxytarget` from fields then perform an assertion if `proxymethod` is not static.

- For the second assertion failure, we remove the `proxytarget` class from the fields then sort them. Further, we sort the `parameter types` too, then perform assertion of these array lists thus we can ensure that the `getDeclaredFields` order does not cause an assert failure in method `net.bytebuddy.implementation.auxiliary.MethodCallProxyTest`
