### PR TITLE
Graal support - Simplifies native image manipulation when bytebuddy as a dependency

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/utility/dispatcher/JavaDispatcher.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/utility/dispatcher/JavaDispatcher.java
@@ -1235,7 +1235,7 @@ public class JavaDispatcher<T> implements PrivilegedAction<T> {
         @SuppressFBWarnings(value = {"REC_CATCH_EXCEPTION", "DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED"}, justification = "Expected internal invocation.")
         protected static Object proxy(Class<?> proxy, Map<Method, Dispatcher> dispatchers) {
             ClassWriter classWriter = new ClassWriter(0);
-            classWriter.visit(ClassFileVersion.ofThisVm(ClassFileVersion.JAVA_V5).getMinorMajorVersion(),
+            classWriter.visit(ClassFileVersion.JAVA_V5.getMinorMajorVersion(),
                     Opcodes.ACC_PUBLIC,
                     Type.getInternalName(proxy) + "$Proxy",
                     null,
@@ -1311,7 +1311,7 @@ public class JavaDispatcher<T> implements PrivilegedAction<T> {
         @SuppressFBWarnings(value = {"REC_CATCH_EXCEPTION", "DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED"}, justification = "Expected internal invocation.")
         protected static Invoker invoker() {
             ClassWriter classWriter = new ClassWriter(0);
-            classWriter.visit(ClassFileVersion.ofThisVm(ClassFileVersion.JAVA_V5).getMinorMajorVersion(),
+            classWriter.visit(ClassFileVersion.JAVA_V5.getMinorMajorVersion(),
                     Opcodes.ACC_PUBLIC,
                     Type.getInternalName(Invoker.class) + "$Dispatcher",
                     null,


### PR DESCRIPTION
When a library A depends on bytebuddy and a program B depends on A, before compiling B with graalvm's native image, the user needs to use the java agent to generate predefined classes files to support the dynamic class generation in the JavaDispatcher of bytebuddy in A. Then the user needs to ensure that Runtime $Version is initialized during build time to ensure that the predefined classes of graal function normally. 
If any step is missing, it will start generating the java5 version of the proxy class after native without corresponding to the product of predefined classes. 
Even after successfully native according to the above process, when the user upgrades the jdk, they have to regenerate the predefined classes that A depends on. I think this should be the responsibility of the author of library A. 

Therefore, this PR will fix the corresponding bytecode generated version to jdk5, so that the author of lib A can directly package the corresponding'net/bytebuddy/utility/Invoker $Dispatcher ' `s predefined classes files into the jar, thus reducing the difficulty of native