### PR TITLE
Fix issue with lazy simple name resolution with valid leading characters

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/description/type/TypeDescription.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/description/type/TypeDescription.java
@@ -8408,7 +8408,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
                         return internalName;
                     }
                 }
-                while (simpleNameIndex < internalName.length() && !Character.isLetter(internalName.charAt(simpleNameIndex))) {
+                while (simpleNameIndex < internalName.length() && !Character.isJavaIdentifierStart(internalName.charAt(simpleNameIndex))) {
                     simpleNameIndex += 1;
                 }
                 return internalName.substring(simpleNameIndex);

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/pool/TypePoolDefaultWithLazyResolutionTypeDescriptionTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/pool/TypePoolDefaultWithLazyResolutionTypeDescriptionTest.java
@@ -224,6 +224,13 @@ public class TypePoolDefaultWithLazyResolutionTypeDescriptionTest extends Abstra
         verifyNoMoreInteractions(classFileLocator);
     }
 
+    @Test
+    @Override
+    public void testSimpleName() throws Exception {
+        super.testSimpleName();
+        assertThat(describe($DollarInName.class).getSimpleName(), CoreMatchers.is($DollarInName.class.getSimpleName()));
+    }
+
     private static class SuperClass {
         /* empty */
     }
@@ -264,5 +271,9 @@ public class TypePoolDefaultWithLazyResolutionTypeDescriptionTest extends Abstra
         T foo(T argument) throws T {
             return argument;
         }
+    }
+
+    private static class $DollarInName {
+        /* empty */
     }
 }


### PR DESCRIPTION
# What does this PR do
Fixes lazy resolution of simple names when the first character of the class is valid and not a letter.

# Motivation
Java identifiers can start with a letter, `$` or `_` according to the [spec](https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.8)

# Links
https://github.com/DataDog/dd-trace-java/issues/6723