### PR TITLE
Don't resolve parameterized types for RAW_TYPES mode

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/description/type/TypeDescription.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/description/type/TypeDescription.java
@@ -1903,9 +1903,14 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
                  */
                 public Generic onParameterizedType(Generic parameterizedType) {
                     Generic ownerType = parameterizedType.getOwnerType();
-                    List<Generic> typeArguments = new ArrayList<Generic>(parameterizedType.getTypeArguments().size());
-                    for (Generic typeArgument : parameterizedType.getTypeArguments()) {
-                        typeArguments.add(typeArgument.accept(this));
+                    List<Generic> typeArguments;
+                    if (TypeDescription.AbstractBase.RAW_TYPES) {
+                        typeArguments = new ArrayList<>();
+                    } else {
+                        typeArguments = new ArrayList<>(parameterizedType.getTypeArguments().size());
+                        for (Generic typeArgument : parameterizedType.getTypeArguments()) {
+                            typeArguments.add(typeArgument.accept(this));
+                        }
                     }
                     return new OfParameterizedType.Latent(parameterizedType.asRawType().accept(this).asErasure(),
                             ownerType == null

--- a/byte-buddy-dep/src/main/java/net/bytebuddy/description/type/TypeDescription.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/description/type/TypeDescription.java
@@ -1905,7 +1905,7 @@ public interface TypeDescription extends TypeDefinition, ByteCodeElement, TypeVa
                     Generic ownerType = parameterizedType.getOwnerType();
                     List<Generic> typeArguments;
                     if (TypeDescription.AbstractBase.RAW_TYPES) {
-                        typeArguments = new ArrayList<>();
+                        typeArguments = Collections.emptyList();
                     } else {
                         typeArguments = new ArrayList<>(parameterizedType.getTypeArguments().size());
                         for (Generic typeArgument : parameterizedType.getTypeArguments()) {

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/description/type/TypeDescriptionGenericVisitorSubstitutorForTypeVariableBindingWithRawTypesTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/description/type/TypeDescriptionGenericVisitorSubstitutorForTypeVariableBindingWithRawTypesTest.java
@@ -25,6 +25,6 @@ public class TypeDescriptionGenericVisitorSubstitutorForTypeVariableBindingWithR
         when(parameterizedType.getTypeArguments()).thenReturn(new TypeList.Generic.Explicit(TypeDescription.Generic.OfNonGenericType.ForLoadedType.of(Object.class)));
         TypeDescription.Generic result = new TypeDescription.Generic.Visitor.Substitutor.ForTypeVariableBinding(visitedType).onParameterizedType(parameterizedType);
 
-        assertThat(result.getTypeArguments(), CoreMatchers.is(new TypeList.Generic.Explicit()));
+        assertThat(result.getTypeArguments(), CoreMatchers.<TypeList.Generic>is(new TypeList.Generic.Explicit()));
     }
 }

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/description/type/TypeDescriptionGenericVisitorSubstitutorForTypeVariableBindingWithRawTypesTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/description/type/TypeDescriptionGenericVisitorSubstitutorForTypeVariableBindingWithRawTypesTest.java
@@ -1,0 +1,31 @@
+package net.bytebuddy.description.type;
+
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TypeDescriptionGenericVisitorSubstitutorForTypeVariableBindingWithRawTypesTest {
+
+    @Mock
+    private TypeDescription.Generic visitedType, parameterizedType, rawType;
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testParameterizedTypeWithRawTypes() throws Exception {
+        System.setProperty(TypeDefinition.RAW_TYPES_PROPERTY, "true");
+        MockitoAnnotations.initMocks(this);
+
+        when(parameterizedType.asRawType()).thenReturn(rawType);
+        when(rawType.accept(any(TypeDescription.Generic.Visitor.class))).thenReturn(rawType);
+        when(parameterizedType.getTypeArguments()).thenReturn(new TypeList.Generic.Explicit(TypeDescription.Generic.OfNonGenericType.ForLoadedType.of(Object.class)));
+        TypeDescription.Generic result = new TypeDescription.Generic.Visitor.Substitutor.ForTypeVariableBinding(visitedType).onParameterizedType(parameterizedType);
+
+        assertThat(result.getTypeArguments(), is(new TypeList.Generic.Explicit()));
+    }
+}

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/description/type/TypeDescriptionGenericVisitorSubstitutorForTypeVariableBindingWithRawTypesTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/description/type/TypeDescriptionGenericVisitorSubstitutorForTypeVariableBindingWithRawTypesTest.java
@@ -1,13 +1,12 @@
 package net.bytebuddy.description.type;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class TypeDescriptionGenericVisitorSubstitutorForTypeVariableBindingWithRawTypesTest {
@@ -26,6 +25,6 @@ public class TypeDescriptionGenericVisitorSubstitutorForTypeVariableBindingWithR
         when(parameterizedType.getTypeArguments()).thenReturn(new TypeList.Generic.Explicit(TypeDescription.Generic.OfNonGenericType.ForLoadedType.of(Object.class)));
         TypeDescription.Generic result = new TypeDescription.Generic.Visitor.Substitutor.ForTypeVariableBinding(visitedType).onParameterizedType(parameterizedType);
 
-        assertThat(result.getTypeArguments(), is(new TypeList.Generic.Explicit()));
+        assertThat(result.getTypeArguments(), CoreMatchers.is(new TypeList.Generic.Explicit()));
     }
 }


### PR DESCRIPTION
Tests in our codebase using Mockito set the `net.bytebuddy.raw` property in ByteBuddy because we apply some particular bytecode transformations, and we've become quite dependent on it. We are working on updating our tests to run on a Java 17 runtime (currently on 11) but ran into an issue where this `onParameterizedType` visitor throws an exception when resolving some generic types, e.g.:

```
Caused by: java.lang.IllegalArgumentException: Cannot resolve E from class org.mockito.codegen.List$MockitoMock$1697292975
	at net.bytebuddy.description.TypeVariableSource$AbstractBase.findExpectedVariable(TypeVariableSource.java:174)
	at net.bytebuddy.dynamic.Transformer$ForMethod$TransformedMethod$AttachmentVisitor.onTypeVariable(Transformer.java:598)
	at net.bytebuddy.dynamic.Transformer$ForMethod$TransformedMethod$AttachmentVisitor.onTypeVariable(Transformer.java:589)
	at net.bytebuddy.description.type.TypeDescription$Generic$OfTypeVariable$Symbolic.accept(TypeDescription.java:5931)
	at net.bytebuddy.description.type.TypeDescription$Generic$Visitor$Substitutor.onParameterizedType(TypeDescription.java:1908)
	at net.bytebuddy.description.type.TypeDescription$Generic$Visitor$Substitutor$WithoutTypeSubstitution.onParameterizedType(TypeDescription.java:1954)
	at net.bytebuddy.description.type.TypeDescription$Generic$OfParameterizedType.accept(TypeDescription.java:5134)
	at net.bytebuddy.dynamic.Transformer$ForMethod$TransformedMethod.getReceiverType(Transformer.java:465)
	at net.bytebuddy.implementation.attribute.MethodAttributeAppender$ForInstrumentedMethod$2.appendReceiver(MethodAttributeAppender.java:177)
	at net.bytebuddy.implementation.attribute.MethodAttributeAppender$ForInstrumentedMethod.apply(MethodAttributeAppender.java:215)
	at net.bytebuddy.implementation.attribute.MethodAttributeAppender$Compound.apply(MethodAttributeAppender.java:484)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$MethodPool$Record$ForDefinedMethod$WithBody.applyAttributes(TypeWriter.java:723)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$MethodPool$Record$ForDefinedMethod$WithBody.applyBody(TypeWriter.java:713)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$MethodPool$Record$ForDefinedMethod.apply(TypeWriter.java:622)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$Default$ForCreation.create(TypeWriter.java:6043)
	at net.bytebuddy.dynamic.scaffold.TypeWriter$Default.make(TypeWriter.java:2224)
	at net.bytebuddy.dynamic.DynamicType$Builder$AbstractBase$UsingTypeWriter.make(DynamicType.java:4055)
	at net.bytebuddy.dynamic.DynamicType$Builder$AbstractBase.make(DynamicType.java:3739)
	at org.mockito.internal.creation.bytebuddy.SubclassBytecodeGenerator.mockClass(SubclassBytecodeGenerator.java:172)
	at org.mockito.internal.creation.bytebuddy.TypeCachingBytecodeGenerator$1.call(TypeCachingBytecodeGenerator.java:37)
	at org.mockito.internal.creation.bytebuddy.TypeCachingBytecodeGenerator$1.call(TypeCachingBytecodeGenerator.java:34)
	at net.bytebuddy.TypeCache.findOrInsert(TypeCache.java:168)
	at net.bytebuddy.TypeCache$WithInlineExpunction.findOrInsert(TypeCache.java:399)
	at net.bytebuddy.TypeCache.findOrInsert(TypeCache.java:190)
	at net.bytebuddy.TypeCache$WithInlineExpunction.findOrInsert(TypeCache.java:410)
	at org.mockito.internal.creation.bytebuddy.TypeCachingBytecodeGenerator.mockClass(TypeCachingBytecodeGenerator.java:32)
	at org.mockito.internal.creation.bytebuddy.InlineBytecodeGenerator.mockClass(InlineBytecodeGenerator.java:157)
	at org.mockito.internal.creation.bytebuddy.TypeCachingBytecodeGenerator$1.call(TypeCachingBytecodeGenerator.java:37)
	at org.mockito.internal.creation.bytebuddy.TypeCachingBytecodeGenerator$1.call(TypeCachingBytecodeGenerator.java:34)
	at net.bytebuddy.TypeCache.findOrInsert(TypeCache.java:168)
	at net.bytebuddy.TypeCache$WithInlineExpunction.findOrInsert(TypeCache.java:399)
	at net.bytebuddy.TypeCache.findOrInsert(TypeCache.java:190)
	at net.bytebuddy.TypeCache$WithInlineExpunction.findOrInsert(TypeCache.java:410)
	at org.mockito.internal.creation.bytebuddy.TypeCachingBytecodeGenerator.mockClass(TypeCachingBytecodeGenerator.java:32)
	at org.mockito.internal.creation.bytebuddy.InlineByteBuddyMockMaker.createMockType(InlineByteBuddyMockMaker.java:198)
	at org.mockito.internal.creation.bytebuddy.InlineByteBuddyMockMaker.createMock(InlineByteBuddyMockMaker.java:178)
	at org.mockito.internal.util.MockUtil.createMock(MockUtil.java:35)
	at org.mockito.internal.MockitoCore.mock(MockitoCore.java:62)
	at org.mockito.internal.stubbing.defaultanswers.ReturnsDeepStubs.newDeepStubMock(ReturnsDeepStubs.java:107)
	at org.mockito.internal.stubbing.defaultanswers.ReturnsDeepStubs.deepStub(ReturnsDeepStubs.java:83)
	at org.mockito.internal.stubbing.defaultanswers.ReturnsDeepStubs.answer(ReturnsDeepStubs.java:67)
	at <REDACTED>
	at org.mockito.internal.handler.MockHandlerImpl.handle(MockHandlerImpl.java:103)
	at org.mockito.internal.handler.NullResultGuardian.handle(NullResultGuardian.java:29)
	at org.mockito.internal.handler.InvocationNotifierHandler.handle(InvocationNotifierHandler.java:35)
	at org.mockito.internal.creation.bytebuddy.MockMethodInterceptor.doIntercept(MockMethodInterceptor.java:61)
	at org.mockito.internal.creation.bytebuddy.MockMethodAdvice.handle(MockMethodAdvice.java:110)
	... 20 more

```

I believe it makes sense to discard the type arguments when operating in RAW_TYPES mode here.