### PR TITLE
[doc] Fix swapped parameter description in `FieldDescription.Latent` Javadoc

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/description/field/FieldDescription.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/description/field/FieldDescription.java
@@ -371,8 +371,8 @@ public interface FieldDescription extends ModifierReviewable.ForFieldDescription
          *
          * @param declaringType       The declaring type of the field.
          * @param name                The name of the field.
-         * @param fieldType           The field's modifiers.
-         * @param modifiers           The type of the field.
+         * @param fieldType           The type of the field.
+         * @param modifiers           The field's modifiers.
          * @param declaredAnnotations The annotations of this field.
          */
         public Latent(TypeDescription declaringType,


### PR DESCRIPTION
I just noticed this and was confused for a second, should be a straightforward change :) 
I considered adding an `@see` for the `java.lang.reflect.Modifier` class but that would need to be done everywhere. Probably better to just hope that people find that on their own :^)

Quite a few methods would also benefit from the inline `{@return}` tag now that I looked at them. You probably build with a new enough Doclet that this is supported. I wonder if that is worth writing an automatic transformation for.