### PR TITLE
Update InstrumentedType.java to check instrumented classfile is in valid Unicode namespace instead

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/dynamic/scaffold/InstrumentedType.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/dynamic/scaffold/InstrumentedType.java
@@ -1842,13 +1842,13 @@ public interface InstrumentedType extends TypeDescription {
          * @return {@code true} if the given identifier is valid.
          */
         private static boolean isValidIdentifier(String identifier) {
-            if (KEYWORDS.contains(identifier) || identifier.length() == 0 || !Character.isJavaIdentifierStart(identifier.charAt(0))) {
+            if (KEYWORDS.contains(identifier) || identifier.length() == 0 || !Character.isUnicodeIdentifierStart(identifier.charAt(0))) {
                 return false;
             } else if (identifier.equals(PackageDescription.PACKAGE_CLASS_NAME)) {
                 return true;
             }
             for (int index = 1; index < identifier.length(); index++) {
-                if (!Character.isJavaIdentifierPart(identifier.charAt(index))) {
+                if (!Character.isUnicodeIdentifierPart(identifier.charAt(index))) {
                     return false;
                 }
             }


### PR DESCRIPTION
We own an Amazon open-source project which utilizes ByteBuddy, and this PR for ByteBuddy solves an obstacle we have encountered while supporting our customers Our project: https://github.com/awslabs/disco

In some cases we need to instrument shaded classes with FQN such as `*.!internal.*` that are [valid JVM classfile names](https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#:~:text=from%20the%20entire-,Unicode%20codespace,-.%20Class%20and%20interface) but are not accepted by the compiler. This is intentionally done to prevent external dependencies from using the shaded classes. These classes’ bytecode are valid and are processed and have its bytecode changed by ASM but failing `InstrumentedType.validate()` post-instrumentation validation because of i`sValidIdentifier()` which only allows Java Identifier characters. Is it possible to add slack to the instrumented classfile name validation to allow characters from the Unicode namespace instead? According to the Oracle's JVM specification, classfile names can be drawn from all of the Unicode namespace (see link above).
