### PR TITLE
Add JavaDoc for NamedPipe handling on Windows

### DIFF
--- a/byte-buddy-agent/src/main/java/net/bytebuddy/agent/VirtualMachine.java
+++ b/byte-buddy-agent/src/main/java/net/bytebuddy/agent/VirtualMachine.java
@@ -1076,9 +1076,10 @@ public interface VirtualMachine {
                 }
 
                 /**
-                 * Custom Security Descriptor is required here to "get" Medium Integrity Level.
+                 * Custom {@link WinBase.SECURITY_ATTRIBUTES} is required here to "get" Medium Integrity Level.
                  * In order to allow Medium Integrity Level clients to open
                  * and use a NamedPipe created by an High Integrity Level process.
+                 * @return A security attributes object that gives everyone read and write access.
                  */
                 private WinBase.SECURITY_ATTRIBUTES createSecurityAttributesToAllowMediumIntegrity() {
                     // Allow read/write to Everybody


### PR DESCRIPTION
This is a follow up for #1616 that adds the required javadoc due to the build error:
```
Error:  /home/runner/work/byte-buddy/byte-buddy/byte-buddy-agent/src/main/java/net/bytebuddy/agent/VirtualMachine.java:1083: @return tag should be present and have description. [JavadocMethod]
````