### PR TITLE
J9 Allow attachment as root

### DIFF
--- a/byte-buddy-agent/src/main/java/net/bytebuddy/agent/VirtualMachine.java
+++ b/byte-buddy-agent/src/main/java/net/bytebuddy/agent/VirtualMachine.java
@@ -1839,6 +1839,11 @@ public interface VirtualMachine {
             }
         }
 
+        /**
+         * Returns the userUid present in the virtualMachine properties file
+         * @param virtualMachine Properties of the J9 attachInfo file
+         * @return the userUid if it can be parsed, <code>0L</code> otherwise.
+         */
         private static long getUserId(Properties virtualMachine) {
             long targetUserId;
             try {


### PR DESCRIPTION
This PR aims to solve #1628 

The J9 attachment allows `root` to start the attachment and be excluded from some of the checks.
By checking all folders as root and also doing a chown on the replyFile, we are able to attach also to user owned JVMs as root.

This is also true upstream in openj9 while reading the attachinfo and writing the replyfile

References:
https://github.com/eclipse-openj9/openj9/blob/master/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/Reply.java#L88-L90
```
if ((ROOT_UID == myUid) && (ROOT_UID != targetUid)) {
  IPC.chownFileToTargetUid(replyFileAbsolutePath, targetUid);
}
```

https://github.com/eclipse-openj9/openj9/blob/master/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/CommonDirectory.java#L418-L426
```
/**
* Check if the file is owned by the UID.  Note that UID 0 "owns" all files.
* @param f File or directory
* @param myUid user UID. 
* @return true if the uid owns the file or uid == 0.
*/
public static boolean isFileOwnedByUid(File f, long myUid) {
  return (0 == myUid) || (myUid == CommonDirectory.getFileOwner(f.getAbsolutePath()));
}
```