### PR TITLE
ci: update harden-runner configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,24 +127,25 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.event_name == 'push'
     steps:
-      - uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # V2.7.0
+      - uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # V2.8.1
         with:
           egress-policy: block
           disable-telemetry: true
           allowed-endpoints: >
-            artifactcache.actions.githubusercontent.com:443
-            aw97acprodeus1file2.blob.core.windows.net:443
             coveralls.io:443
+            dl.google.com:443
             docs.gradle.org:443
             docs.oracle.com:443
-            downloads.gradle-dn.com:443
             github.com:443
             javadoc.io:443
+            jcenter.bintray.com:443
+            objects.githubusercontent.com:443
             plugins-artifacts.gradle.org:443
             plugins.gradle.org:443
             raw.githubusercontent.com:443
             repo.gradle.org:443
             repo.maven.apache.org:443
+            repository.sonatype.org:443
             services.gradle.org:443
       - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
       - uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2 # v3.12.0
@@ -163,7 +164,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # V2.7.0
+      - uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # V2.8.1
         with:
           egress-policy: audit # servers have changed, must be adjusted after next release
       - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3


### PR DESCRIPTION
Related to https://github.com/step-security/harden-runner/issues/167

I noticed that `downloads.gradle-dn.com` is no longer a valid domain. Since it was in the block policy but could not be resolved, harden-runner was reverting the policy. 

Couple more were not needed that I have removed:
`artifactcache.actions.githubusercontent.com:443` does not have to be allowed explicitly, as it is always allowed
`aw97acprodeus1file2.blob.core.windows.net:443` is a cache endpoint and does not have to be allowed explicitly, as harden-runner auto-detects cache endpoints and adds to allowed list. 

When I ran this job in a fork in audit mode, it needed few more endpoints, which I have added. 

I have also bumped the harden-runner version. 