### PR TITLE
Fix bug in Android SDK > 28

### DIFF
--- a/byte-buddy-android/src/main/java/net/bytebuddy/android/AndroidClassLoadingStrategy.java
+++ b/byte-buddy-android/src/main/java/net/bytebuddy/android/AndroidClassLoadingStrategy.java
@@ -891,7 +891,7 @@ public abstract class AndroidClassLoadingStrategy implements ClassLoadingStrateg
                         throw new IllegalArgumentException("On Android P, a class injection can only be applied to BaseDexClassLoader: " + classLoader);
                     }
                     try {
-                        addDexPath.invoke(classLoader, jar.getAbsolutePath(), true);
+                        addDexPath.invoke(classLoader, jar.getAbsolutePath(), false);
                         return NO_RETURN_VALUE;
                     } catch (IllegalAccessException exception) {
                         throw new IllegalStateException("Cannot access BaseDexClassLoader#addDexPath(String, boolean)", exception);


### PR DESCRIPTION
This flag is for dex with permission to access restricted APIs, however this causes an error on Android 9 or higher. It was changed because it was not necessary