### PR TITLE
Add `PrimitiveNarrowingDelegate`

### DIFF
--- a/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/bytecode/assign/primitive/PrimitiveNarrowingDelegate.java
+++ b/byte-buddy-dep/src/main/java/net/bytebuddy/implementation/bytecode/assign/primitive/PrimitiveNarrowingDelegate.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright 2014 - Present Rafael Winterhalter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.bytebuddy.implementation.bytecode.assign.primitive;
+
+import net.bytebuddy.build.HashCodeAndEqualsPlugin;
+import net.bytebuddy.description.type.TypeDefinition;
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.implementation.bytecode.StackManipulation;
+import net.bytebuddy.implementation.bytecode.StackSize;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+/**
+ * This delegate is responsible for narrowing a primitive type to represent a <i>smaller</i> primitive type. The
+ * rules for this narrowing are equivalent to those in the <a href="http://docs.oracle.com/javase/specs/">JLS</a>.
+ * This class also includes the byte-to-char conversion in widening and narrowing primitive conversions.
+ */
+public enum PrimitiveNarrowingDelegate {
+
+    /**
+     * The narrowing delegate for {@code boolean} values.
+     */
+    BOOLEAN(StackManipulation.Trivial.INSTANCE,                                                     // to boolean
+            StackManipulation.Illegal.INSTANCE,                                                     // to byte
+            StackManipulation.Illegal.INSTANCE,                                                     // to short
+            StackManipulation.Illegal.INSTANCE,                                                     // to character
+            StackManipulation.Illegal.INSTANCE,                                                     // to integer
+            StackManipulation.Illegal.INSTANCE,                                                     // to long
+            StackManipulation.Illegal.INSTANCE,                                                     // to float
+            StackManipulation.Illegal.INSTANCE),                                                    // to double
+
+    /**
+     * The narrowing delegate for {@code byte} values.
+     */
+    BYTE(StackManipulation.Illegal.INSTANCE,                                                        // to boolean
+            StackManipulation.Trivial.INSTANCE,                                                     // to byte
+            StackManipulation.Illegal.INSTANCE,                                                     // to short
+            new PrimitiveNarrowingDelegate.NarrowingStackManipulation(
+                    new int[]{Opcodes.I2C}, StackSize.ZERO.toDecreasingSize()),                     // to character
+            StackManipulation.Illegal.INSTANCE,                                                     // to integer
+            StackManipulation.Illegal.INSTANCE,                                                     // to long
+            StackManipulation.Illegal.INSTANCE,                                                     // to float
+            StackManipulation.Illegal.INSTANCE),                                                    // to double
+
+    /**
+     * The narrowing delegate for {@code short} values.
+     */
+    SHORT(StackManipulation.Illegal.INSTANCE,                                                       // to boolean
+            new PrimitiveNarrowingDelegate.NarrowingStackManipulation(
+                    new int[]{Opcodes.I2B}, StackSize.ZERO.toDecreasingSize()),                     // to byte
+            StackManipulation.Trivial.INSTANCE,                                                     // to short
+            new PrimitiveNarrowingDelegate.NarrowingStackManipulation(
+                    new int[]{Opcodes.I2C}, StackSize.ZERO.toDecreasingSize()),                     // to character
+            StackManipulation.Illegal.INSTANCE,                                                     // to integer
+            StackManipulation.Illegal.INSTANCE,                                                     // to long
+            StackManipulation.Illegal.INSTANCE,                                                     // to float
+            StackManipulation.Illegal.INSTANCE),                                                    // to double
+
+    /**
+     * The narrowing delegate for {@code char} values.
+     */
+    CHARACTER(StackManipulation.Illegal.INSTANCE,                                                   // to boolean
+            new PrimitiveNarrowingDelegate.NarrowingStackManipulation(
+                    new int[]{Opcodes.I2B}, StackSize.ZERO.toDecreasingSize()),                     // to byte
+            new PrimitiveNarrowingDelegate.NarrowingStackManipulation(
+                    new int[]{Opcodes.I2S}, StackSize.ZERO.toDecreasingSize()),                     // to short
+            StackManipulation.Trivial.INSTANCE,                                                     // to character
+            StackManipulation.Illegal.INSTANCE,                                                     // to integer
+            StackManipulation.Illegal.INSTANCE,                                                     // to long
+            StackManipulation.Illegal.INSTANCE,                                                     // to float
+            StackManipulation.Illegal.INSTANCE),                                                    // to double
+
+    /**
+     * The narrowing delegate for {@code int} values.
+     */
+    INTEGER(StackManipulation.Illegal.INSTANCE,                                                     // to boolean
+            new PrimitiveNarrowingDelegate.NarrowingStackManipulation(
+                    new int[]{Opcodes.I2B}, StackSize.ZERO.toDecreasingSize()),                     // to byte
+            new PrimitiveNarrowingDelegate.NarrowingStackManipulation(
+                    new int[]{Opcodes.I2S}, StackSize.ZERO.toDecreasingSize()),                     // to short
+            new PrimitiveNarrowingDelegate.NarrowingStackManipulation(
+                    new int[]{Opcodes.I2C}, StackSize.ZERO.toDecreasingSize()),                     // to character
+            StackManipulation.Trivial.INSTANCE,                                                     // to integer
+            StackManipulation.Illegal.INSTANCE,                                                     // to long
+            StackManipulation.Illegal.INSTANCE,                                                     // to float
+            StackManipulation.Illegal.INSTANCE),                                                    // to double
+
+    /**
+     * The narrowing delegate for {@code long} values.
+     */
+    LONG(StackManipulation.Illegal.INSTANCE,                                                        // to boolean
+            new PrimitiveNarrowingDelegate.NarrowingStackManipulation(
+                    new int[]{Opcodes.L2I, Opcodes.I2B}, StackSize.SINGLE.toDecreasingSize()),      // to byte
+            new PrimitiveNarrowingDelegate.NarrowingStackManipulation(
+                    new int[]{Opcodes.L2I, Opcodes.I2S}, StackSize.SINGLE.toDecreasingSize()),      // to short
+            new PrimitiveNarrowingDelegate.NarrowingStackManipulation(
+                    new int[]{Opcodes.L2I, Opcodes.I2C}, StackSize.SINGLE.toDecreasingSize()),      // to character
+            new PrimitiveNarrowingDelegate.NarrowingStackManipulation(
+                    new int[]{Opcodes.L2I}, StackSize.SINGLE.toDecreasingSize()),                   // to integer
+            StackManipulation.Trivial.INSTANCE,                                                     // to long
+            StackManipulation.Illegal.INSTANCE,                                                     // to float
+            StackManipulation.Illegal.INSTANCE),                                                    // to double
+
+    /**
+     * The narrowing delegate for {@code float} values.
+     */
+    FLOAT(StackManipulation.Illegal.INSTANCE,                                                       // to boolean
+            new PrimitiveNarrowingDelegate.NarrowingStackManipulation(
+                    new int[]{Opcodes.F2I, Opcodes.I2B}, StackSize.ZERO.toDecreasingSize()),        // to byte
+            new PrimitiveNarrowingDelegate.NarrowingStackManipulation(
+                    new int[]{Opcodes.F2I, Opcodes.I2S}, StackSize.ZERO.toDecreasingSize()),        // to short
+            new PrimitiveNarrowingDelegate.NarrowingStackManipulation(
+                    new int[]{Opcodes.F2I, Opcodes.I2C}, StackSize.ZERO.toDecreasingSize()),        // to character
+            new PrimitiveNarrowingDelegate.NarrowingStackManipulation(
+                    new int[]{Opcodes.F2I}, StackSize.ZERO.toDecreasingSize()),                     // to integer
+            new PrimitiveNarrowingDelegate.NarrowingStackManipulation(
+                    new int[]{Opcodes.F2L}, StackSize.SINGLE.toIncreasingSize()),                   // to long
+            StackManipulation.Trivial.INSTANCE,                                                     // to float
+            StackManipulation.Illegal.INSTANCE),                                                    // to double
+
+    /**
+     * The narrowing delegate for {@code double} values.
+     */
+    DOUBLE(StackManipulation.Illegal.INSTANCE,                                                      // to boolean
+            new PrimitiveNarrowingDelegate.NarrowingStackManipulation(
+                    new int[]{Opcodes.D2I, Opcodes.I2B}, StackSize.SINGLE.toDecreasingSize()),      // to byte
+            new PrimitiveNarrowingDelegate.NarrowingStackManipulation(
+                    new int[]{Opcodes.D2I, Opcodes.I2S}, StackSize.SINGLE.toDecreasingSize()),      // to short
+            new PrimitiveNarrowingDelegate.NarrowingStackManipulation(
+                    new int[]{Opcodes.D2I, Opcodes.I2C}, StackSize.SINGLE.toDecreasingSize()),      // to character
+            new PrimitiveNarrowingDelegate.NarrowingStackManipulation(
+                    new int[]{Opcodes.D2I}, StackSize.SINGLE.toDecreasingSize()),                   // to integer
+            new PrimitiveNarrowingDelegate.NarrowingStackManipulation(
+                    new int[]{Opcodes.D2L}, StackSize.ZERO.toDecreasingSize()),                     // to long
+            new PrimitiveNarrowingDelegate.NarrowingStackManipulation(
+                    new int[]{Opcodes.D2F}, StackSize.SINGLE.toDecreasingSize()),                   // to float
+            StackManipulation.Trivial.INSTANCE);                                                    // to double
+
+    /**
+     * A stack manipulation that narrows the type that is represented by this instance to a {@code boolean}.
+     */
+    private final StackManipulation toBooleanStackManipulation;
+
+    /**
+     * A stack manipulation that narrows the type that is represented by this instance to a {@code byte}.
+     */
+    private final StackManipulation toByteStackManipulation;
+
+    /**
+     * A stack manipulation that narrows the type that is represented by this instance to a {@code short}.
+     */
+    private final StackManipulation toShortStackManipulation;
+
+    /**
+     * A stack manipulation that narrows the type that is represented by this instance to a {@code char}.
+     */
+    private final StackManipulation toCharacterStackManipulation;
+
+    /**
+     * A stack manipulation that narrows the type that is represented by this instance to a {@code int}.
+     */
+    private final StackManipulation toIntegerStackManipulation;
+
+    /**
+     * A stack manipulation that narrows the type that is represented by this instance to a {@code long}.
+     */
+    private final StackManipulation toLongStackManipulation;
+
+    /**
+     * A stack manipulation that narrows the type that is represented by this instance to a {@code float}.
+     */
+    private final StackManipulation toFloatStackManipulation;
+
+    /**
+     * A stack manipulation that narrows the type that is represented by this instance to a {@code double}.
+     */
+    private final StackManipulation toDoubleStackManipulation;
+
+    /**
+     * Creates a new primitive narrowing delegate.
+     *
+     * @param toBooleanStackManipulation   A stack manipulation that narrows the type that is represented by this
+     *                                     instance to a {@code boolean}.
+     * @param toByteStackManipulation      A stack manipulation that narrows the type that is represented by this
+     *                                     instance to a {@code byte}.
+     * @param toShortStackManipulation     A stack manipulation that narrows the type that is represented by this
+     *                                     instance to a {@code short}.
+     * @param toCharacterStackManipulation A stack manipulation that narrows the type that is represented by this
+     *                                     instance to a {@code char}.
+     * @param toIntegerStackManipulation   A stack manipulation that narrows the type that is represented by this
+     *                                     instance to a {@code int}.
+     * @param toLongStackManipulation      A stack manipulation that narrows the type that is represented by this
+     *                                     instance to a {@code long}.
+     * @param toFloatStackManipulation     A stack manipulation that narrows the type that is represented by this
+     *                                     instance to a {@code float}.
+     * @param toDoubleStackManipulation    A stack manipulation that narrows the type that is represented by this
+     *                                     instance to a {@code double}.
+     */
+    PrimitiveNarrowingDelegate(StackManipulation toBooleanStackManipulation,
+                               StackManipulation toByteStackManipulation,
+                               StackManipulation toShortStackManipulation,
+                               StackManipulation toCharacterStackManipulation,
+                               StackManipulation toIntegerStackManipulation,
+                               StackManipulation toLongStackManipulation,
+                               StackManipulation toFloatStackManipulation,
+                               StackManipulation toDoubleStackManipulation) {
+        this.toBooleanStackManipulation = toBooleanStackManipulation;
+        this.toByteStackManipulation = toByteStackManipulation;
+        this.toShortStackManipulation = toShortStackManipulation;
+        this.toCharacterStackManipulation = toCharacterStackManipulation;
+        this.toIntegerStackManipulation = toIntegerStackManipulation;
+        this.toLongStackManipulation = toLongStackManipulation;
+        this.toFloatStackManipulation = toFloatStackManipulation;
+        this.toDoubleStackManipulation = toDoubleStackManipulation;
+    }
+
+    /**
+     * Locates the delegate that is capable of narrowing the given type into another type.
+     *
+     * @param typeDefinition A non-void primitive type that is to be narrowed into another type.
+     * @return A delegate for the given type.
+     */
+    public static PrimitiveNarrowingDelegate forPrimitive(TypeDefinition typeDefinition) {
+        if (typeDefinition.represents(boolean.class)) {
+            return BOOLEAN;
+        } else if (typeDefinition.represents(byte.class)) {
+            return BYTE;
+        } else if (typeDefinition.represents(short.class)) {
+            return SHORT;
+        } else if (typeDefinition.represents(char.class)) {
+            return CHARACTER;
+        } else if (typeDefinition.represents(int.class)) {
+            return INTEGER;
+        } else if (typeDefinition.represents(long.class)) {
+            return LONG;
+        } else if (typeDefinition.represents(float.class)) {
+            return FLOAT;
+        } else if (typeDefinition.represents(double.class)) {
+            return DOUBLE;
+        } else {
+            throw new IllegalArgumentException("Not a primitive, non-void type: " + typeDefinition);
+        }
+    }
+
+    /**
+     * Attempts to narrow the represented type into another type.
+     *
+     * @param typeDefinition A non-void primitive type that is the expected result of the narrowing operation.
+     * @return A narrowing instruction or an illegal stack manipulation if such narrowing is not legitimate.
+     */
+    public StackManipulation narrowTo(TypeDefinition typeDefinition) {
+        if (typeDefinition.represents(boolean.class)) {
+            return toBooleanStackManipulation;
+        } else if (typeDefinition.represents(byte.class)) {
+            return toByteStackManipulation;
+        } else if (typeDefinition.represents(short.class)) {
+            return toShortStackManipulation;
+        } else if (typeDefinition.represents(char.class)) {
+            return toCharacterStackManipulation;
+        } else if (typeDefinition.represents(int.class)) {
+            return toIntegerStackManipulation;
+        } else if (typeDefinition.represents(long.class)) {
+            return toLongStackManipulation;
+        } else if (typeDefinition.represents(float.class)) {
+            return toFloatStackManipulation;
+        } else if (typeDefinition.represents(double.class)) {
+            return toDoubleStackManipulation;
+        } else {
+            throw new IllegalArgumentException("Not a primitive non-void type: " + typeDefinition);
+        }
+    }
+
+    /**
+     * A stack manipulation that narrows a primitive type into a smaller primitive type.
+     */
+    @HashCodeAndEqualsPlugin.Enhance
+    protected static class NarrowingStackManipulation extends StackManipulation.AbstractBase {
+
+        /**
+         * The opcode for executing the conversion.
+         */
+        private final int[] conversionOpcodes;
+
+        /**
+         * The size change of applying the conversion.
+         */
+        private final Size size;
+
+        /**
+         * Creates a new narrowing stack manipulation.
+         *
+         * @param conversionOpcodes The opcodes for executing the conversion.
+         * @param size              The size change of applying the conversion.
+         */
+        protected NarrowingStackManipulation(int[] conversionOpcodes, Size size) {
+            this.conversionOpcodes = conversionOpcodes;
+            this.size = size;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        public Size apply(MethodVisitor methodVisitor, Implementation.Context context) {
+            for (int conversionOpcode : conversionOpcodes) {
+                methodVisitor.visitInsn(conversionOpcode);
+            }
+            return size;
+        }
+    }
+}

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/bytecode/assign/primitive/PrimitiveNarrowingDelegateIllegalTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/bytecode/assign/primitive/PrimitiveNarrowingDelegateIllegalTest.java
@@ -1,0 +1,99 @@
+package net.bytebuddy.implementation.bytecode.assign.primitive;
+
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.implementation.bytecode.StackManipulation;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.MethodRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.objectweb.asm.MethodVisitor;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.*;
+
+@RunWith(Parameterized.class)
+public class PrimitiveNarrowingDelegateIllegalTest {
+
+    private final TypeDescription sourceTypeDescription;
+
+    private final TypeDescription targetTypeDescription;
+
+    @Rule
+    public MethodRule mockitoRule = MockitoJUnit.rule().silent();
+
+    @Mock
+    private MethodVisitor methodVisitor;
+
+    @Mock
+    private Implementation.Context implementationContext;
+
+    public PrimitiveNarrowingDelegateIllegalTest(Class<?> sourceType, Class<?> targetType) {
+        sourceTypeDescription = mock(TypeDescription.class);
+        when(sourceTypeDescription.isPrimitive()).thenReturn(true);
+        when(sourceTypeDescription.represents(sourceType)).thenReturn(true);
+        targetTypeDescription = mock(TypeDescription.class);
+        when(targetTypeDescription.isPrimitive()).thenReturn(true);
+        when(targetTypeDescription.represents(targetType)).thenReturn(true);
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {boolean.class, byte.class},
+                {boolean.class, short.class},
+                {boolean.class, char.class},
+                {boolean.class, int.class},
+                {boolean.class, long.class},
+                {boolean.class, float.class},
+                {boolean.class, double.class},
+                {byte.class, boolean.class},
+                {byte.class, short.class},
+                {byte.class, int.class},
+                {byte.class, long.class},
+                {byte.class, float.class},
+                {byte.class, double.class},
+                {short.class, boolean.class},
+                {short.class, int.class},
+                {short.class, long.class},
+                {short.class, float.class},
+                {short.class, double.class},
+                {char.class, boolean.class},
+                {char.class, int.class},
+                {char.class, long.class},
+                {char.class, float.class},
+                {char.class, double.class},
+                {int.class, boolean.class},
+                {int.class, long.class},
+                {int.class, float.class},
+                {int.class, double.class},
+                {long.class, boolean.class},
+                {long.class, float.class},
+                {long.class, double.class},
+                {float.class, boolean.class},
+                {float.class, double.class},
+                {double.class, boolean.class},
+        });
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        verifyNoMoreInteractions(methodVisitor);
+        verifyNoMoreInteractions(implementationContext);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testIllegalBoolean() throws Exception {
+        StackManipulation stackManipulation = PrimitiveNarrowingDelegate.forPrimitive(sourceTypeDescription).narrowTo(targetTypeDescription);
+        assertThat(stackManipulation.isValid(), is(false));
+        stackManipulation.apply(methodVisitor, implementationContext);
+    }
+}

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/bytecode/assign/primitive/PrimitiveNarrowingDelegateNontrivialTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/bytecode/assign/primitive/PrimitiveNarrowingDelegateNontrivialTest.java
@@ -1,0 +1,110 @@
+package net.bytebuddy.implementation.bytecode.assign.primitive;
+
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.implementation.bytecode.StackManipulation;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.MethodRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.*;
+
+@RunWith(Parameterized.class)
+public class PrimitiveNarrowingDelegateNontrivialTest {
+
+    private final Class<?> sourceType;
+
+    private final Class<?> targetType;
+
+    private final int sizeChange;
+
+    private final int[] opcodes;
+
+    @Rule
+    public MethodRule mockitoRule = MockitoJUnit.rule().silent();
+
+    @Mock
+    private TypeDescription sourceTypeDescription, targetTypeDescription;
+
+    @Mock
+    private MethodVisitor methodVisitor;
+
+    @Mock
+    private Implementation.Context implementationContext;
+
+    public PrimitiveNarrowingDelegateNontrivialTest(Class<?> sourceType,
+                                                    Class<?> targetType,
+                                                    int sizeChange,
+                                                    int[] opcodes) {
+        this.sourceType = sourceType;
+        this.targetType = targetType;
+        this.sizeChange = sizeChange;
+        this.opcodes = opcodes;
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {byte.class, char.class, 0, new int[]{Opcodes.I2C}},
+                {short.class, byte.class, 0, new int[]{Opcodes.I2B}},
+                {short.class, char.class, 0, new int[]{Opcodes.I2C}},
+                {char.class, byte.class, 0, new int[]{Opcodes.I2B}},
+                {char.class, short.class, 0, new int[]{Opcodes.I2S}},
+                {int.class, byte.class, 0, new int[]{Opcodes.I2B}},
+                {int.class, short.class, 0, new int[]{Opcodes.I2S}},
+                {int.class, char.class, 0, new int[]{Opcodes.I2C}},
+                {long.class, byte.class, -1, new int[]{Opcodes.L2I, Opcodes.I2B}},
+                {long.class, short.class, -1, new int[]{Opcodes.L2I, Opcodes.I2S}},
+                {long.class, char.class, -1, new int[]{Opcodes.L2I, Opcodes.I2C}},
+                {long.class, int.class, -1, new int[]{Opcodes.L2I}},
+                {float.class, byte.class, 0, new int[]{Opcodes.F2I, Opcodes.I2B}},
+                {float.class, short.class, 0, new int[]{Opcodes.F2I, Opcodes.I2S}},
+                {float.class, char.class, 0, new int[]{Opcodes.F2I, Opcodes.I2C}},
+                {float.class, int.class, 0, new int[]{Opcodes.F2I}},
+                {float.class, long.class, 1, new int[]{Opcodes.F2L}},
+                {double.class, byte.class, -1, new int[]{Opcodes.D2I, Opcodes.I2B}},
+                {double.class, short.class, -1, new int[]{Opcodes.D2I, Opcodes.I2S}},
+                {double.class, char.class, -1, new int[]{Opcodes.D2I, Opcodes.I2C}},
+                {double.class, int.class, -1, new int[]{Opcodes.D2I}},
+                {double.class, long.class, 0, new int[]{Opcodes.D2L}},
+                {double.class, float.class, -1, new int[]{Opcodes.D2F}},
+        });
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        when(sourceTypeDescription.represents(sourceType)).thenReturn(true);
+        when(targetTypeDescription.represents(targetType)).thenReturn(true);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        verifyNoMoreInteractions(implementationContext);
+    }
+
+    @Test
+    public void testNarrowingConversion() throws Exception {
+        StackManipulation stackManipulation = PrimitiveNarrowingDelegate.forPrimitive(sourceTypeDescription).narrowTo(targetTypeDescription);
+        assertThat(stackManipulation.isValid(), is(true));
+        StackManipulation.Size size = stackManipulation.apply(methodVisitor, implementationContext);
+        assertThat(size.getSizeImpact(), is(sizeChange));
+        assertThat(size.getMaximalSize(), is(Math.max(0, sizeChange)));
+        for (int opcode : opcodes) {
+            verify(this.methodVisitor).visitInsn(opcode);
+        }
+        verifyNoMoreInteractions(this.methodVisitor);
+    }
+}

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/bytecode/assign/primitive/PrimitiveNarrowingDelegateOtherTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/bytecode/assign/primitive/PrimitiveNarrowingDelegateOtherTest.java
@@ -1,0 +1,17 @@
+package net.bytebuddy.implementation.bytecode.assign.primitive;
+
+import net.bytebuddy.description.type.TypeDescription;
+import org.junit.Test;
+
+public class PrimitiveNarrowingDelegateOtherTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIllegalSourceTypeThrowsException() throws Exception {
+        PrimitiveNarrowingDelegate.forPrimitive(TypeDescription.ForLoadedType.of(Object.class));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIllegalTargetTypeThrowsException() throws Exception {
+        PrimitiveNarrowingDelegate.forPrimitive(TypeDescription.ForLoadedType.of(int.class)).narrowTo(TypeDescription.ForLoadedType.of(Object.class));
+    }
+}

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/bytecode/assign/primitive/PrimitiveNarrowingDelegateTrivialTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/implementation/bytecode/assign/primitive/PrimitiveNarrowingDelegateTrivialTest.java
@@ -1,0 +1,84 @@
+package net.bytebuddy.implementation.bytecode.assign.primitive;
+
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.implementation.bytecode.StackManipulation;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.MethodRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.objectweb.asm.MethodVisitor;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.*;
+
+@RunWith(Parameterized.class)
+public class PrimitiveNarrowingDelegateTrivialTest {
+
+    private final Class<?> sourceType;
+
+    private final Class<?> targetType;
+
+    @Rule
+    public MethodRule mockitoRule = MockitoJUnit.rule().silent();
+
+    @Mock
+    private TypeDescription sourceTypeDescription, targetTypeDescription;
+
+    @Mock
+    private MethodVisitor methodVisitor;
+
+    @Mock
+    private Implementation.Context implementationContext;
+
+    public PrimitiveNarrowingDelegateTrivialTest(Class<?> sourceType, Class<?> targetType) {
+        this.sourceType = sourceType;
+        this.targetType = targetType;
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {boolean.class, boolean.class},
+                {byte.class, byte.class},
+                {short.class, short.class},
+                {char.class, char.class},
+                {int.class, int.class},
+                {long.class, long.class},
+                {float.class, float.class},
+                {double.class, double.class}
+        });
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        when(sourceTypeDescription.represents(sourceType)).thenReturn(true);
+        when(targetTypeDescription.represents(targetType)).thenReturn(true);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        verifyNoMoreInteractions(implementationContext);
+        verifyNoMoreInteractions(methodVisitor);
+    }
+
+    @Test
+    public void testNoOpAssignment() throws Exception {
+        StackManipulation stackManipulation = PrimitiveNarrowingDelegate.forPrimitive(sourceTypeDescription).narrowTo(targetTypeDescription);
+        assertThat(stackManipulation.isValid(), is(true));
+        StackManipulation.Size size = stackManipulation.apply(methodVisitor, implementationContext);
+        assertThat(size.getSizeImpact(), is(0));
+        assertThat(size.getMaximalSize(), is(0));
+        verify(sourceTypeDescription, atLeast(1)).represents(sourceType);
+        verify(targetTypeDescription, atLeast(1)).represents(sourceType);
+    }
+}


### PR DESCRIPTION
While `PrimitiveWideningDelegate` was already implemented, `PrimitiveNarrowingDelegate` was missing, so I implemented it.
`PrimitiveNarrowingDelegate` implements the following two conversions:
- [Narrowing Primitive Conversion](https://docs.oracle.com/javase/specs/jls/se24/html/jls-5.html#jls-5.1.3)
- [Widening and Narrowing Primitive Conversion](https://docs.oracle.com/javase/specs/jls/se24/html/jls-5.html#jls-5.1.4)