### PR TITLE
Add 'requires static com.github.spotbugs.annotations' to module-info

### DIFF
--- a/byte-buddy/pom.xml
+++ b/byte-buddy/pom.xml
@@ -189,7 +189,8 @@
                                 jdk.unsupported,
                                 net.bytebuddy.agent,
                                 com.sun.jna,
-                                com.sun.jna.platform
+                                com.sun.jna.platform,
+                                com.github.spotbugs.annotations
                             </static-requires>
                             <main-class>net.bytebuddy.build.Plugin$Engine$Default</main-class>
                         </configuration>


### PR DESCRIPTION
Hi. I noticed this in a strict _module path_ project.

This change is required for annotation processors to see the annotation classes (if the spotbugs Jar is on the module path). It is needed for `javac` to succeed when annotation processing is performed with the `-Xlint:all` (or `-Xlint: classfile`) and `-Werror` flags turned on.

The change won't fail the compilation in other cases. It's very much like an optional dependency declaration. 

Without this change, I get the following error:

```
> Compilation failed; see the compiler output below.
  byte-buddy-1.17.5.jar(/net/bytebuddy/utility/RandomString.class): warning: Cannot find annotation method 'value()' in type 'SuppressFBWarnings': class file for edu.umd.cs.findbugs.annotations.SuppressFBWarnings not found
  1 error
  2 warnings
```

More background on this behavior is discussed in the corresponding Log4j issue:
https://github.com/apache/logging-log4j2/issues/3437#issuecomment-2640495652

