### PR TITLE
Fix incorrect URL in effective POM for Maven modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+        child.project.url.inherit.append.path="false">
+
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>net.bytebuddy</groupId>
@@ -151,7 +153,9 @@
         <url>https://github.com/raphw/byte-buddy/issues</url>
     </issueManagement>
 
-    <scm>
+    <!-- These attributes specify that the URLs should be inherited by the modules as is, to avoid constructing
+        invalid URLs, see also https://maven.apache.org/ref/3.9.9/maven-model-builder/index.html#inheritance-assembly -->
+    <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
         <connection>scm:git:${repository.url}</connection>
         <developerConnection>scm:git:${repository.url}</developerConnection>
         <url>${repository.url}</url>


### PR DESCRIPTION
Fixes #718

See https://maven.apache.org/ref/3.9.9/maven-model-builder/index.html#inheritance-assembly for a description of these attributes.

You can see the effect of this by running `mvn help:effective-pom` for the Maven modules and comparing the changes.