### PR TITLE
Use JVMS 4.2.2 "Unqualified name" definition to validate identifier

### DIFF
--- a/byte-buddy-dep/src/test/java/net/bytebuddy/dynamic/scaffold/InstrumentedTypeDefaultTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/dynamic/scaffold/InstrumentedTypeDefaultTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.*;
 
 public class InstrumentedTypeDefaultTest {
 
-    private static final String FOO = "foo", BAR = "bar", QUX = "qux", BAZ = "baz", ILLEGAL_NAME = "<>";
+    private static final String FOO = "foo", BAR = "bar", QUX = "qux", BAZ = "baz", ILLEGAL_NAME = "the;name";
 
     private static final int ILLEGAL_MODIFIERS = -1, OTHER_MODIFIERS = 42;
 


### PR DESCRIPTION
Hey Rafael,

Following our [google group discussion](https://groups.google.com/g/byte-buddy/c/VXwBPt_-3AQ), I managed to take some time to improve identifier name validation.
I validated the implementation check against the current [OpenJDK parser code](https://github.com/openjdk/jdk21u-dev/blob/f55ff018b2f6a14e7f751d29f56205aba33e8b69/src/hotspot/share/classfile/classFileParser.cpp#L4664).

I created two additional methods. I hesitated to create a single method, to avoid the almost same loop in both methods. But I went for readability in this case. Let me know what you think.

Hope this helps,
Guillaume

