### PR TITLE
fix: prevent Lazy TypePool from drifting after type resolution

### DIFF
--- a/byte-buddy-dep/src/test/java/net/bytebuddy/pool/TypePoolCacheProviderTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/pool/TypePoolCacheProviderTest.java
@@ -1,5 +1,6 @@
 package net.bytebuddy.pool;
 
+import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatchers;
 import org.junit.Rule;
 import org.junit.Test;
@@ -80,6 +81,18 @@ public class TypePoolCacheProviderTest {
         discriminating.clear();
         verify(matched).clear();
         verify(unmatched).clear();
+    }
+
+    @Test
+    public void testWithIllegalResolutionReattempt() throws Exception {
+        TypePool.CacheProvider cacheProvider = TypePool.CacheProvider.WithIllegalResolutionReattempt.of(new TypePool.CacheProvider.Simple());
+        TypePool.Resolution illegal = new TypePool.Resolution.Illegal(FOO);
+        assertThat(cacheProvider.register(FOO, illegal), sameInstance(illegal));
+        assertThat(cacheProvider.find(FOO), nullValue(TypePool.Resolution.class));
+        TypePool.Resolution legal = new TypePool.Resolution.Simple(TypeDescription.ForLoadedType.of(Object.class));
+        assertThat(cacheProvider.register(FOO, legal), sameInstance(legal));
+        assertThat(cacheProvider.find(FOO), sameInstance(legal));
+        assertThat(TypePool.CacheProvider.WithIllegalResolutionReattempt.of(cacheProvider), sameInstance(cacheProvider));
     }
 
     @Test

--- a/byte-buddy-dep/src/test/java/net/bytebuddy/pool/TypePoolDefaultWithLazyResolutionTypeDescriptionTest.java
+++ b/byte-buddy-dep/src/test/java/net/bytebuddy/pool/TypePoolDefaultWithLazyResolutionTypeDescriptionTest.java
@@ -78,6 +78,19 @@ public class TypePoolDefaultWithLazyResolutionTypeDescriptionTest extends Abstra
     }
 
     @Test
+    public void testIllegalResolutionDoesNotPersist() throws Exception {
+        TypePool typePool = new TypePool.Default.WithLazyResolution(new TypePool.CacheProvider.Simple(),
+                ClassFileLocator.NoOp.INSTANCE,
+                TypePool.Default.ReaderMode.FAST,
+                lazinessMode);
+        String name = "foo.Bar";
+        TypePool.Resolution resolution = typePool.describe(name);
+        assertThat(resolution.resolve().getName(), CoreMatchers.is(name));
+        assertThat(resolution.isResolved(), CoreMatchers.is(false));
+        assertThat(typePool.describe(name).resolve().getName(), CoreMatchers.is(name));
+    }
+
+    @Test
     public void testTypeIsLazy() throws Exception {
         ClassFileLocator classFileLocator = spy(ClassFileLocator.ForClassLoader.ofSystemLoader());
         TypePool typePool = TypePool.Default.WithLazyResolution.of(classFileLocator);


### PR DESCRIPTION
A Lazy TypePool was mutating during type resolution, causing its configuration to deviate from the initial state. This commit ensures the TypePool retains its original configuration by freezing the base state before resolution and isolating resolved types in a temporary context.