### PR TITLE
Make gradle plugin configuration cache friendly

### DIFF
--- a/byte-buddy-gradle-plugin/src/main/java/net/bytebuddy/build/gradle/ByteBuddySimpleTask.java
+++ b/byte-buddy-gradle-plugin/src/main/java/net/bytebuddy/build/gradle/ByteBuddySimpleTask.java
@@ -173,9 +173,11 @@ public class ByteBuddySimpleTask extends AbstractByteBuddyTask {
      */
     @TaskAction
     public void apply() throws IOException {
-        if (!getSource().equals(getTarget()) && deleteRecursively(getProject().fileTree(getTarget()).getFiles())) {
-            getLogger().debug("Deleted all target files in {}", getTarget());
+        File source = getSource();
+        File target = getTarget();
+        if (!source.equals(target) && deleteRecursively(target)) {
+            getLogger().debug("Deleted all target files in {}", target);
         }
-        doApply(new Plugin.Engine.Source.ForFolder(getSource()), new Plugin.Engine.Target.ForFolder(getTarget()));
+        doApply(new Plugin.Engine.Source.ForFolder(source), new Plugin.Engine.Target.ForFolder(target));
     }
 }


### PR DESCRIPTION
The important change in this PR is removing the call to `getProject()`, see https://docs.gradle.org/current/userguide/configuration_cache_requirements.html#config_cache:requirements:use_project_during_execution