### PR TITLE
Update tutorial.partial.cn.html

### DIFF
--- a/partial/tutorial.partial.cn.html
+++ b/partial/tutorial.partial.cn.html
@@ -428,13 +428,13 @@ DynamicType.Unloaded&lt;?&gt; dynamicType = new ByteBuddy()
 
 <pre class="prettyprint">
 ByteBuddy byteBuddy = new ByteBuddy();
-byteBuddy.withNamingStrategy(new NamingStrategy.SuffixingRandom("suffix"));
+byteBuddy.with(new NamingStrategy.SuffixingRandom("suffix"));
 DynamicType.Unloaded&lt;?&gt; dynamicType = byteBuddy.subclass(Object.class).make();
 </pre>
 
 <p>
     你可能期望用自定义命名策略<code>new NamingStrategy.SuffixingRandom("suffix")</code>生成动态类型。
-    <code>withNamingStrategy</code>方法的调用不是改变存储在<code>byteBuddy</code>变量中的实例，
+    <code>with</code>方法的调用不是改变存储在<code>byteBuddy</code>变量中的实例，
     而是返回一个自定义且丢失了的<code>ByteBuddy</code>实例。因此，此动态类型是用原始创建的默认配置创建的。
 </p>
 


### PR DESCRIPTION
Fix an inconsistent code/description between the Chinese version tutorial and the English version tutorial

What we can see in [the English version tutorial](https://bytebuddy.net/#/tutorial) is as follows
<img width="2386" height="1150" alt="image" src="https://github.com/user-attachments/assets/95c57c22-353e-4c6d-bfa3-949ee30ea0c8" />

While in [the Chinese version tutorial](https://bytebuddy.net/#/tutorial-cn), the corresponding content is a bit different (as shown below) and won't compile as I tried. So I updated the code/description in it.
<img width="2486" height="1358" alt="image" src="https://github.com/user-attachments/assets/f7e3f6e4-22eb-4e70-8d40-85a0054308ed" />
