### PR TITLE
Use @Classpath instead of @CompileClasspath for byteBuddy task inputs

### DIFF
--- a/byte-buddy-gradle-plugin/src/main/java/net/bytebuddy/build/gradle/ByteBuddyJarTask.java
+++ b/byte-buddy-gradle-plugin/src/main/java/net/bytebuddy/build/gradle/ByteBuddyJarTask.java
@@ -17,7 +17,7 @@ package net.bytebuddy.build.gradle;
 
 import net.bytebuddy.build.Plugin;
 import net.bytebuddy.utility.nullability.MaybeNull;
-import org.gradle.api.tasks.CompileClasspath;
+import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Optional;
@@ -110,7 +110,7 @@ public class ByteBuddyJarTask extends AbstractByteBuddyTask {
      * @return The class path to supply to the plugin engine.
      */
     @InputFiles
-    @CompileClasspath
+    @Classpath
     public Iterable<File> getClassPath() {
         return classPath;
     }

--- a/byte-buddy-gradle-plugin/src/main/java/net/bytebuddy/build/gradle/ByteBuddyJarsTask.java
+++ b/byte-buddy-gradle-plugin/src/main/java/net/bytebuddy/build/gradle/ByteBuddyJarsTask.java
@@ -18,7 +18,7 @@ package net.bytebuddy.build.gradle;
 import net.bytebuddy.build.Plugin;
 import net.bytebuddy.utility.QueueFactory;
 import net.bytebuddy.utility.nullability.MaybeNull;
-import org.gradle.api.tasks.CompileClasspath;
+import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Optional;
@@ -114,7 +114,7 @@ public class ByteBuddyJarsTask extends AbstractByteBuddyTask {
      * @return The class path to supply to the plugin engine.
      */
     @InputFiles
-    @CompileClasspath
+    @Classpath
     public Iterable<File> getClassPath() {
         return classPath;
     }

--- a/byte-buddy-gradle-plugin/src/main/java/net/bytebuddy/build/gradle/ByteBuddySimpleTask.java
+++ b/byte-buddy-gradle-plugin/src/main/java/net/bytebuddy/build/gradle/ByteBuddySimpleTask.java
@@ -17,7 +17,7 @@ package net.bytebuddy.build.gradle;
 
 import net.bytebuddy.build.Plugin;
 import net.bytebuddy.utility.nullability.MaybeNull;
-import org.gradle.api.tasks.CompileClasspath;
+import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Optional;
@@ -110,7 +110,7 @@ public class ByteBuddySimpleTask extends AbstractByteBuddyTask {
      * @return The class path to supply to the plugin engine.
      */
     @InputFiles
-    @CompileClasspath
+    @Classpath
     public Iterable<File> getClassPath() {
         return classPath;
     }

--- a/byte-buddy-gradle-plugin/src/main/java/net/bytebuddy/build/gradle/ByteBuddyTask.java
+++ b/byte-buddy-gradle-plugin/src/main/java/net/bytebuddy/build/gradle/ByteBuddyTask.java
@@ -20,7 +20,7 @@ import net.bytebuddy.utility.nullability.MaybeNull;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.tasks.CompileClasspath;
+import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
@@ -87,7 +87,7 @@ public abstract class ByteBuddyTask extends AbstractByteBuddyTask {
      * @return The class path to supply to the plugin engine.
      */
     @InputFiles
-    @CompileClasspath
+    @Classpath
     public abstract ConfigurableFileCollection getClassPath();
 
     /**
@@ -270,7 +270,7 @@ public abstract class ByteBuddyTask extends AbstractByteBuddyTask {
     public abstract static class WithIncrementalClassPath extends ByteBuddyTask {
 
         @Incremental
-        @CompileClasspath
+        @Classpath
         @Override
         public abstract ConfigurableFileCollection getClassPath();
 

--- a/byte-buddy-gradle-plugin/src/test/java/net/bytebuddy/build/gradle/ByteBuddyPluginTest.java
+++ b/byte-buddy-gradle-plugin/src/test/java/net/bytebuddy/build/gradle/ByteBuddyPluginTest.java
@@ -1,5 +1,8 @@
 package net.bytebuddy.build.gradle;
 
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.description.modifier.Visibility;
+import net.bytebuddy.implementation.FixedValue;
 import net.bytebuddy.jar.asm.ClassReader;
 import net.bytebuddy.jar.asm.ClassVisitor;
 import net.bytebuddy.jar.asm.FieldVisitor;
@@ -21,6 +24,7 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,6 +35,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
+import java.util.jar.JarOutputStream;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -229,6 +234,84 @@ public class ByteBuddyPluginTest {
         assertThat(task.getOutcome(), is(TaskOutcome.SUCCESS));
         assertResult(FOO, "sample/", "SampleClass.class");
         assertThat(result.task(":byteBuddyTest"), nullValue(BuildTask.class));
+    }
+
+    @Test
+    @IntegrationRule.Enforce
+    public void testClassPathFingerprintTracksMethodBodies() throws Exception {
+        // Verifies the task's classPath input uses @Classpath (full bytecode hashing) rather
+        // than @CompileClasspath (ABI-only), since plugins may inspect arbitrary bytecode.
+        File dependencyJar = new File(folder, "dependency.jar");
+        writeClassPathJar(dependencyJar, 1);
+        write("build.gradle",
+            "plugins {",
+            "  id 'java'",
+            "  id 'net.bytebuddy.byte-buddy-gradle-plugin'",
+            "}",
+            "dependencies {",
+            "  implementation files('" + dependencyJar.getAbsolutePath().replace('\\', '/') + "')",
+            "}",
+            "byteBuddy {",
+            "  transformation {",
+            "    plugin = net.bytebuddy.build.Plugin.NoOp.class",
+            "  }",
+            "}");
+        write("src/main/java/sample/SampleClass.java",
+            "package sample;",
+            "public class SampleClass { }");
+        // Prime the cache. GradleRunner.build() throws on failure, so no outcome assertion
+        // is needed here.
+        GradleRunner.create()
+            .withProjectDir(folder)
+            .withArguments("byteBuddy")
+            .withPluginClasspath()
+            .build();
+
+        // Re-run with no input changes: the task must be UP_TO_DATE. This rules out the
+        // possibility that a third-run SUCCESS is caused by some unrelated volatile input
+        // rather than by the classpath jar swap performed below.
+        TaskOutcome unchangedOutcome = GradleRunner.create()
+            .withProjectDir(folder)
+            .withArguments("byteBuddy")
+            .withPluginClasspath()
+            .build()
+            .task(":byteBuddy")
+            .getOutcome();
+        assertThat(unchangedOutcome, is(TaskOutcome.UP_TO_DATE));
+
+        // Replace the dependency jar with a variant that has the SAME ABI but a different
+        // method body. With @CompileClasspath this change is invisible to the cache key
+        // and the task is incorrectly reported as UP_TO_DATE. With @Classpath the
+        // byte-level change busts the fingerprint and the task re-executes (SUCCESS).
+        writeClassPathJar(dependencyJar, 2);
+        TaskOutcome swappedOutcome = GradleRunner.create()
+            .withProjectDir(folder)
+            .withArguments("byteBuddy")
+            .withPluginClasspath()
+            .build()
+            .task(":byteBuddy")
+            .getOutcome();
+        assertThat(swappedOutcome, is(TaskOutcome.SUCCESS));
+    }
+
+    private static void writeClassPathJar(File jar, int constant) throws IOException {
+        // Two invocations with different `constant` values share the same public ABI but
+        // have different method bodies, so they must produce different bytecode hashes.
+        byte[] bytes = new ByteBuddy()
+            .subclass(Object.class)
+            .name("sample.ClassPathClass")
+            .defineMethod("value", int.class, Visibility.PUBLIC)
+            .intercept(FixedValue.value(constant))
+            .make()
+            .getBytes();
+        JarOutputStream out = new JarOutputStream(new FileOutputStream(jar));
+        try {
+            out.putNextEntry(new JarEntry("sample/ClassPathClass.class"));
+            out.write(bytes);
+            out.closeEntry();
+        } finally {
+            out.close();
+        }
     }
 
     private File create(List<String> segments) {


### PR DESCRIPTION
Byte Buddy `Plugin` implementations can read full bytecode and resources from classes on the task's `classPath` — not just their public ABI. The Gradle tasks were annotating `getClassPath()` with `@CompileClasspath`, which fingerprints inputs using compile-avoidance hashing: method bodies, private members, and resources are normalized away. Two classpaths that share an ABI but differ in method bodies therefore produce the same cache key, causing the task to be reported `UP_TO_DATE` even when its output legitimately depends on the changed bytes.

Switch all four task classes (`ByteBuddyTask`, `ByteBuddyJarTask`, `ByteBuddyJarsTask`, `ByteBuddySimpleTask`, plus the `WithIncrementalClassPath` override) to `@Classpath`, which uses full content hashing while still preserving classpath-order semantics.

Adds an integration test (`testClassPathFingerprintTracksMethodBodies`) that builds a jar, re-runs to confirm `UP_TO_DATE`, then replaces the jar with a same-ABI/different-body variant and asserts the task re-executes.