### PR TITLE
Improve diagnostics for external agent attachment

### DIFF
--- a/byte-buddy-agent/src/main/java/net/bytebuddy/agent/Attacher.java
+++ b/byte-buddy-agent/src/main/java/net/bytebuddy/agent/Attacher.java
@@ -27,10 +27,11 @@ import java.lang.reflect.InvocationTargetException;
  */
 public class Attacher {
 
-    /**
-     * Indicates that any error during attachment should be dumped to a given file location.
-     */
-    public static final String DUMP_PROPERTY = "net.bytebuddy.agent.attacher.dump";
+	/**
+	 * Indicates that any error during attachment should be dumped to a given file location.
+	 * When set for external attachment, diagnostic information is appended to this file.
+	 */
+	public static final String DUMP_PROPERTY = "net.bytebuddy.agent.attacher.dump";
 
     /**
      * The attacher provides only {@code static} utility methods and should not be instantiated.

--- a/byte-buddy-agent/src/main/java/net/bytebuddy/agent/ByteBuddyAgent.java
+++ b/byte-buddy-agent/src/main/java/net/bytebuddy/agent/ByteBuddyAgent.java
@@ -670,18 +670,22 @@ public class ByteBuddyAgent {
             for (File jar : externalAttachment.getClassPath()) {
                 classPath.append(File.pathSeparatorChar).append(jar.getCanonicalPath());
             }
-            if (new ProcessBuilder(System.getProperty(JAVA_HOME)
-                    + File.separatorChar + "bin"
-                    + File.separatorChar + (System.getProperty(OS_NAME, "").toLowerCase(Locale.US).contains("windows") ? "java.exe" : "java"),
-                    "-D" + Attacher.DUMP_PROPERTY + AGENT_ARGUMENT_SEPARATOR + System.getProperty(Attacher.DUMP_PROPERTY, ""),
-                    CLASS_PATH_ARGUMENT,
-                    classPath.toString(),
-                    Attacher.class.getName(),
-                    externalAttachment.getVirtualMachineType(),
-                    processId,
-                    agent.getAbsolutePath(),
-                    Boolean.toString(isNative),
-                    argument == null ? "" : (AGENT_ARGUMENT_SEPARATOR + argument)).start().waitFor() != 0) {
+            List<String> command = new ArrayList<String>();
+            command.add(System.getProperty(JAVA_HOME) + File.separatorChar + "bin" + File.separatorChar
+                    + (System.getProperty(OS_NAME, "").toLowerCase(Locale.US).contains("windows") ? "java.exe" : "java"));
+            command.add("-D" + Attacher.DUMP_PROPERTY + AGENT_ARGUMENT_SEPARATOR + System.getProperty(Attacher.DUMP_PROPERTY, ""));
+            command.add(CLASS_PATH_ARGUMENT);
+            command.add(classPath.toString());
+            command.add(Attacher.class.getName());
+            command.add(externalAttachment.getVirtualMachineType());
+            command.add(processId);
+            command.add(agent.getAbsolutePath());
+            command.add(Boolean.toString(isNative));
+            command.add(argument == null ? "" : (AGENT_ARGUMENT_SEPARATOR + argument));
+
+            dumpExternalAttachmentCommand(command);
+
+            if (new ProcessBuilder(command).start().waitFor() != 0) {
                 throw new IllegalStateException("Could not self-attach to current VM using external process - set a property "
                         + Attacher.DUMP_PROPERTY
                         + " to dump the process output to a file at the specified location");
@@ -690,6 +694,37 @@ public class ByteBuddyAgent {
             if (attachmentJar != null) {
                 if (!attachmentJar.delete()) {
                     attachmentJar.deleteOnExit();
+                }
+            }
+        }
+    }
+    /**
+     * Dumps the external attachment command if a dump location is configured.
+     *
+     * @param arguments The external attachment process arguments.
+     */
+    private static void dumpExternalAttachmentCommand(List<String> arguments) {
+        String dump = System.getProperty(Attacher.DUMP_PROPERTY);
+        if (dump == null || dump.length() == 0) {
+            return;
+        }
+        OutputStream outputStream = null;
+        try {
+            outputStream = new FileOutputStream(dump, true);
+            outputStream.write("Byte Buddy external attachment command line:".getBytes("UTF-8"));
+            outputStream.write(System.lineSeparator().getBytes("UTF-8"));
+            for (String argument : arguments) {
+                outputStream.write(argument.getBytes("UTF-8"));
+                outputStream.write(System.lineSeparator().getBytes("UTF-8"));
+            }
+        } catch (IOException ignored) {
+            /* do nothing */
+        } finally {
+            if (outputStream != null) {
+                try {
+                    outputStream.close();
+                } catch (IOException ignored) {
+                    /* do nothing */
                 }
             }
         }


### PR DESCRIPTION
## Summary

Improves diagnostics for external Byte Buddy agent attachment.

When `net.bytebuddy.agent.attacher.dump` is configured, the generated external attachment command line is appended to the configured dump file before the external attacher process is started.

## Motivation

Issue #1602 mentions that external attachment failures can be difficult to troubleshoot because users only see the final failure message. Including the generated command line in the existing dump output makes it easier to inspect the Java executable, classpath, attacher class, target VM type, process id, agent path, and native flag used for the external attachment attempt.

## Changes

- Refactors the external attachment process command into a `List<String>`
- Appends the generated command line to the configured dump file
- Keeps normal behavior unchanged when `net.bytebuddy.agent.attacher.dump` is not configured
- Leaves the existing external process invocation behavior unchanged

## Scope

This PR intentionally does not add support for extra JVM arguments or change attachment behavior. Those parts may require a separate design discussion.

Addresses part of #1602.

## Testing

- `./mvnw -pl byte-buddy-agent -am test`
- `./mvnw -pl byte-buddy-agent -am -DskipTests package`
- Ran a local reflection-based smoke test to invoke the external attachment path with `net.bytebuddy.agent.attacher.dump=/tmp/byte-buddy-attacher.dump`
- Verified the dump file contains the generated external attachment command line before the attacher failure details
- Verified an invalid dump path does not introduce a new failure in the external attachment flow
- Verified no dump file is created when `net.bytebuddy.agent.attacher.dump` is not configured

Example verified dump content:

```text
Byte Buddy external attachment command line:
/Library/Java/JavaVirtualMachines/jdk-1.8.jdk/Contents/Home/jre/bin/java
-Dnet.bytebuddy.agent.attacher.dump=/tmp/byte-buddy-attacher.dump
-cp
...
net.bytebuddy.agent.Attacher
com.sun.tools.attach.VirtualMachine
...
false
```