### PR TITLE
Support library modules with AGP9 new DSL

### DIFF
--- a/byte-buddy-gradle-plugin/android-plugin/src/main/java/net/bytebuddy/build/gradle/android/ByteBuddyAndroidPlugin.java
+++ b/byte-buddy-gradle-plugin/android-plugin/src/main/java/net/bytebuddy/build/gradle/android/ByteBuddyAndroidPlugin.java
@@ -20,6 +20,7 @@ import com.android.build.api.artifact.Artifact;
 import com.android.build.api.artifact.Artifacts;
 import com.android.build.api.artifact.MultipleArtifact;
 import com.android.build.api.attributes.BuildTypeAttr;
+import com.android.build.api.dsl.CommonExtension;
 import com.android.build.api.instrumentation.InstrumentationScope;
 import com.android.build.api.variant.AndroidComponentsExtension;
 import com.android.build.api.variant.Variant;
@@ -37,7 +38,6 @@ import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.UnknownDomainObjectException;
 import org.gradle.api.artifacts.ArtifactView;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.attributes.Attribute;
@@ -197,7 +197,7 @@ public class ByteBuddyAndroidPlugin implements Plugin<Project> {
                 Provider<ByteBuddyAndroidService> byteBuddyAndroidServiceProvider = project.getGradle().getSharedServices().registerIfAbsent(
                         variantName + "ByteBuddyAndroidService",
                         ByteBuddyAndroidService.class,
-                        ByteBuddyAndroidService.ConfigurationAction.of(project.getExtensions()));
+                        new ByteBuddyAndroidService.ConfigurationAction(project.getExtensions().getByType(CommonExtension.class)));
                 FileCollection classPath = RuntimeClassPathResolver.INSTANCE.apply(variant);
                 variant.getInstrumentation().transformClassesWith(ByteBuddyAsmClassVisitorFactory.class, InstrumentationScope.ALL, new ByteBuddyTransformationConfiguration(project,
                         variantResolvableConfiguration,
@@ -347,11 +347,7 @@ public class ByteBuddyAndroidPlugin implements Plugin<Project> {
          */
         public Unit invoke(ByteBuddyInstrumentationParameters parameters) {
             parameters.getByteBuddyClasspath().from(ByteBuddyViewConfiguration.toClassPath(project, configuration));
-            try {
-                parameters.getAndroidBootClasspath().from(project.getExtensions().getByType(AndroidComponentsExtension.class).getSdkComponents().getBootClasspath());
-            } catch (UnknownDomainObjectException ignored) {
-                parameters.getAndroidBootClasspath().from(project.getExtensions().getByType(BaseExtension.class).getBootClasspath());
-            }
+            parameters.getAndroidBootClasspath().from(project.getExtensions().getByType(AndroidComponentsExtension.class).getSdkComponents().getBootClasspath());
             parameters.getRuntimeClasspath().from(classPath);
             parameters.getByteBuddyService().set(byteBuddyAndroidServiceProvider);
             return Unit.INSTANCE;
@@ -612,9 +608,11 @@ public class ByteBuddyAndroidPlugin implements Plugin<Project> {
                 }
                 TaskProvider<ByteBuddyLocalClassesEnhancerTask> provider = project.getTasks().register(variant.getName() + "BytebuddyTransform",
                     ByteBuddyLocalClassesEnhancerTask.class,
-                    ByteBuddyLocalClassesEnhancerTask.ConfigurationAction.of(
+                    new ByteBuddyLocalClassesEnhancerTask.ConfigurationAction(
                             ByteBuddyViewConfiguration.toClassPath(project, configuration),
-                            project.getExtensions()));
+                            project.getExtensions().getByType(CommonExtension.class),
+                            project.getExtensions().getByType(AndroidComponentsExtension.class),
+                            project.getExtensions().getByType(ByteBuddyAndroidTaskExtension.class)));
                 try {
                     toTransform.invoke(use.invoke(forScope.invoke(variant.getArtifacts(), scope), provider),
                         artifact,

--- a/byte-buddy-gradle-plugin/android-plugin/src/main/java/net/bytebuddy/build/gradle/android/ByteBuddyAndroidService.java
+++ b/byte-buddy-gradle-plugin/android-plugin/src/main/java/net/bytebuddy/build/gradle/android/ByteBuddyAndroidService.java
@@ -15,8 +15,7 @@
  */
 package net.bytebuddy.build.gradle.android;
 
-import com.android.build.api.dsl.ApplicationExtension;
-import com.android.build.gradle.BaseExtension;
+import com.android.build.api.dsl.CommonExtension;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.ClassFileVersion;
 import net.bytebuddy.asm.ClassVisitorFactory;
@@ -33,10 +32,8 @@ import net.bytebuddy.utility.nullability.MaybeNull;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.JavaVersion;
-import org.gradle.api.UnknownDomainObjectException;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.api.provider.Property;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
@@ -382,29 +379,15 @@ public abstract class ByteBuddyAndroidService implements BuildService<ByteBuddyA
         /**
          * The base extension.
          */
-        private final ApplicationExtension extension;
+        private final CommonExtension<?, ?, ?, ?> extension;
 
         /**
          * Creates a new configuration action.
          *
          * @param extension The base extension.
          */
-        protected ConfigurationAction(ApplicationExtension extension) {
+        protected ConfigurationAction(CommonExtension<?, ?, ?, ?> extension) {
             this.extension = extension;
-        }
-
-        /**
-         * Resolves a configuration action for the current platform.
-         *
-         * @param container The extension container to query.
-         * @return An appropriate configuration action.
-         */
-        protected static Action<BuildServiceSpec<Parameters>> of(ExtensionContainer container) {
-            try {
-                return new ConfigurationAction(container.getByType(ApplicationExtension.class));
-            } catch (UnknownDomainObjectException ignored) {
-                return new ForLegacyAndroid(container.getByType(BaseExtension.class));
-            }
         }
 
         /**
@@ -414,36 +397,6 @@ public abstract class ByteBuddyAndroidService implements BuildService<ByteBuddyA
             spec.getParameters()
                     .getJavaTargetCompatibilityVersion()
                     .set(extension.getCompileOptions().getTargetCompatibility());
-        }
-
-        /**
-         * A configuration action for the {@link BuildServiceSpec} of the {@link Parameters} of {@link ByteBuddyAndroidService}
-         * used on legacy Android platforms that do not support the current extension.
-         */
-        protected static class ForLegacyAndroid implements Action<BuildServiceSpec<Parameters>> {
-
-            /**
-             * The base extension.
-             */
-            private final BaseExtension extension;
-
-            /**
-             * Creates a new configuration action.
-             *
-             * @param extension The base extension.
-             */
-            protected ForLegacyAndroid(BaseExtension extension) {
-                this.extension = extension;
-            }
-
-            /**
-             * {@inheritDoc}
-             */
-            public void execute(BuildServiceSpec<Parameters> spec) {
-                spec.getParameters()
-                        .getJavaTargetCompatibilityVersion()
-                        .set(extension.getCompileOptions().getTargetCompatibility());
-            }
         }
     }
 

--- a/byte-buddy-gradle-plugin/android-plugin/src/main/java/net/bytebuddy/build/gradle/android/ByteBuddyLocalClassesEnhancerTask.java
+++ b/byte-buddy-gradle-plugin/android-plugin/src/main/java/net/bytebuddy/build/gradle/android/ByteBuddyLocalClassesEnhancerTask.java
@@ -15,9 +15,8 @@
  */
 package net.bytebuddy.build.gradle.android;
 
-import com.android.build.api.dsl.ApplicationExtension;
+import com.android.build.api.dsl.CommonExtension;
 import com.android.build.api.variant.AndroidComponentsExtension;
-import com.android.build.gradle.BaseExtension;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.ClassFileVersion;
 import net.bytebuddy.build.AndroidDescriptor;
@@ -31,14 +30,12 @@ import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.JavaVersion;
-import org.gradle.api.UnknownDomainObjectException;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.logging.Logger;
-import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
@@ -321,7 +318,7 @@ public abstract class ByteBuddyLocalClassesEnhancerTask extends DefaultTask {
         /**
          * The Android Gradle extension.
          */
-        private final ApplicationExtension applicationExtension;
+        private final CommonExtension<?, ?, ?, ?> commonExtension;
 
         /**
          * The Android components extension.
@@ -335,89 +332,26 @@ public abstract class ByteBuddyLocalClassesEnhancerTask extends DefaultTask {
 
         /**
          * @param byteBuddyClassPath         The current variant Byte Buddy configuration.
-         * @param applicationExtension       The Android Gradle extension.
+         * @param commonExtension            The Android Gradle extension.
          * @param androidComponentsExtension The Android components extension.
          * @param byteBuddyExtension         The Byte Buddy task extension.
          */
         protected ConfigurationAction(FileCollection byteBuddyClassPath,
-                                      ApplicationExtension applicationExtension,
+                                      CommonExtension<?, ?, ?, ?> commonExtension,
                                       AndroidComponentsExtension<?, ?, ?> androidComponentsExtension,
                                       ByteBuddyAndroidTaskExtension byteBuddyExtension) {
             this.byteBuddyClassPath = byteBuddyClassPath;
-            this.applicationExtension = applicationExtension;
+            this.commonExtension = commonExtension;
             this.androidComponentsExtension = androidComponentsExtension;
             this.byteBuddyExtension = byteBuddyExtension;
-        }
-
-        /**
-         * Resolves an appropriate configuration action for the current Android platform.
-         * @param byteBuddyClassPath The current variant Byte Buddy configuration.
-         * @param container          The extensions container to use.
-         * @return An appropriate configuration action.
-         */
-        @SuppressWarnings("unchecked")
-        public static Action<ByteBuddyLocalClassesEnhancerTask> of(FileCollection byteBuddyClassPath, ExtensionContainer container) {
-            try {
-                return new ConfigurationAction(byteBuddyClassPath,
-                        container.getByType(ApplicationExtension.class),
-                        container.getByType(AndroidComponentsExtension.class),
-                        container.getByType(ByteBuddyAndroidTaskExtension.class));
-            } catch (UnknownDomainObjectException ignored) {
-                return new ForLegacyAndroid(byteBuddyClassPath,
-                        container.getByType(BaseExtension.class),
-                        container.getByType(ByteBuddyAndroidTaskExtension.class));
-            }
         }
 
         @Override
         public void execute(ByteBuddyLocalClassesEnhancerTask task) {
             task.getByteBuddyClasspath().from(byteBuddyClassPath);
             task.getAndroidBootClasspath().from(androidComponentsExtension.getSdkComponents().getBootClasspath());
-            task.getJavaTargetCompatibilityVersion().set(applicationExtension.getCompileOptions().getTargetCompatibility());
+            task.getJavaTargetCompatibilityVersion().set(commonExtension.getCompileOptions().getTargetCompatibility());
             byteBuddyExtension.configure(task);
-        }
-
-        /**
-         * A configuration action for the {@link ByteBuddyLocalClassesEnhancerTask} task for
-         * legacy Android platforms.
-         */
-        protected static class ForLegacyAndroid implements Action<ByteBuddyLocalClassesEnhancerTask> {
-
-            /**
-             * The current variant's Byte Buddy configuration.
-             */
-            private final FileCollection byteBuddyClassPath;
-
-            /**
-             * The Android Gradle extension.
-             */
-            private final BaseExtension baseExtension;
-
-            /**
-             * The Byte Buddy task extension.
-             */
-            private final ByteBuddyAndroidTaskExtension byteBuddyExtension;
-
-            /**
-             * @param byteBuddyClassPath The current variant Byte Buddy configuration.
-             * @param baseExtension      The Android Gradle extension.
-             * @param byteBuddyExtension The Byte Buddy task extension.
-             */
-            protected ForLegacyAndroid(FileCollection byteBuddyClassPath,
-                                       BaseExtension baseExtension,
-                                       ByteBuddyAndroidTaskExtension byteBuddyExtension) {
-                this.byteBuddyClassPath = byteBuddyClassPath;
-                this.baseExtension = baseExtension;
-                this.byteBuddyExtension = byteBuddyExtension;
-            }
-
-            @Override
-            public void execute(ByteBuddyLocalClassesEnhancerTask task) {
-                task.getByteBuddyClasspath().from(byteBuddyClassPath);
-                task.getAndroidBootClasspath().from(baseExtension.getBootClasspath());
-                task.getJavaTargetCompatibilityVersion().set(baseExtension.getCompileOptions().getTargetCompatibility());
-                byteBuddyExtension.configure(task);
-            }
         }
     }
 


### PR DESCRIPTION
The [Android 9](https://github.com/raphw/byte-buddy/pull/1881) pull request only fixes AGP 9 with new DSL enabled for application modules, but library modules still fail since they do not have an `ApplicationExtension`.

This pull request reverts some of the changes from the original pull request and updates it to work with all types of Android Gradle modules. The rationale for the changes:

- `AndroidComponentsExtension` is supported by all the Android Gradle Plugin versions supported by Byte Buddy, as it already existed in [version 7.2](https://developer.android.com/reference/tools/gradle-api/7.2/com/android/build/api/dsl/SdkComponents).
- `CommonExtension` is supported all the way back to [7.2](https://developer.android.com/reference/tools/gradle-api/7.2/com/android/build/api/dsl/CommonExtension) and all the way up to [9.1](https://developer.android.com/reference/tools/gradle-api/9.1/com/android/build/api/dsl/CommonExtension), and works with the new DSL disabled or enabled.

Verified the following projects build successfully with these changes:

- Dummy Android application project on AGP 7.2.0.
- Dummy Android library project on AGP 8.10.0.
- Dummy Android application project on AGP 9.1.0 with new DSL enabled.
- Android library project on 9.1.0 with new DSL disabled.
- Android library project on 9.1.0 with new DSL enabled.